### PR TITLE
feat: delete APIs + auto-vacuum on delete; maintenance queue + worker pool

### DIFF
--- a/src/main/java/io/github/panghy/vectorsearch/tasks/MaintenanceService.java
+++ b/src/main/java/io/github/panghy/vectorsearch/tasks/MaintenanceService.java
@@ -1,0 +1,171 @@
+package io.github.panghy.vectorsearch.tasks;
+
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.CompletableFuture.completedFuture;
+
+import com.apple.foundationdb.Database;
+import com.apple.foundationdb.KeyValue;
+import com.apple.foundationdb.Range;
+import com.apple.foundationdb.subspace.Subspace;
+import com.apple.foundationdb.tuple.Tuple;
+import com.google.protobuf.InvalidProtocolBufferException;
+import io.github.panghy.vectorsearch.config.VectorIndexConfig;
+import io.github.panghy.vectorsearch.fdb.FdbDirectories;
+import io.github.panghy.vectorsearch.proto.SegmentMeta;
+import io.github.panghy.vectorsearch.proto.VectorRecord;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Maintenance operations for a VectorIndex.
+ *
+ * <p>This service provides two primary capabilities:
+ * <ul>
+ *   <li><b>Vacuum</b>: Physically removes rows that have been logically deleted (tombstoned)
+ *       from an individual segment. Vacuum clears the raw vector record, the PQ code, and the
+ *       graph adjacency entry, and then decrements {@code deleted_count} in {@code SegmentMeta}.
+ *       Writes are chunked using the same approximate-transaction-size controls used by the
+ *       segment build path, so it respects FoundationDB's 10MB/5s constraints.</li>
+ *   <li><b>Compaction (skeleton)</b>: Placeholder method for future segment merge/compaction.
+ *       Currently a no-op with informative logging.</li>
+ * </ul>
+ *
+ * <p>The class is intentionally stateless aside from injected configuration and directory handles,
+ * and all methods are non-blocking (async) to align with project guidelines.</p>
+ */
+public final class MaintenanceService {
+  private static final Logger LOG = LoggerFactory.getLogger(MaintenanceService.class);
+
+  private final VectorIndexConfig config;
+  private final FdbDirectories.IndexDirectories indexDirs;
+
+  public MaintenanceService(VectorIndexConfig cfg, FdbDirectories.IndexDirectories dirs) {
+    this.config = requireNonNull(cfg, "config");
+    this.indexDirs = requireNonNull(dirs, "indexDirs");
+  }
+
+  /**
+   * Vacuum a single segment: remove tombstoned vector records, PQ codes, and adjacency entries.
+   *
+   * <p>If {@code minDeletedRatio} is greater than zero, the method first checks the
+   * ratio {@code deleted_count / (deleted_count + count)} from {@code SegmentMeta} and returns
+   * early when below the threshold.</p>
+   *
+   * @param segId segment identifier
+   * @param minDeletedRatio minimum deletion ratio required to perform the vacuum (0 to always run)
+   * @return a future completing when vacuum is finished or a no-op if below threshold
+   */
+  public CompletableFuture<Void> vacuumSegment(int segId, double minDeletedRatio) {
+    Database db = config.getDatabase();
+    String segStr = String.format("%06d", segId);
+    var sk = indexDirs.segmentKeys(segStr);
+    return db.readAsync(tr -> tr.get(sk.metaKey())).thenCompose(metaBytes -> {
+      if (metaBytes == null) return completedFuture(null);
+      SegmentMeta sm;
+      try {
+        sm = SegmentMeta.parseFrom(metaBytes);
+      } catch (InvalidProtocolBufferException e) {
+        throw new RuntimeException(e);
+      }
+      long live = sm.getCount();
+      long del = sm.getDeletedCount();
+      double ratio = (live + del) == 0 ? 0.0 : ((double) del) / ((double) (live + del));
+      if (minDeletedRatio > 0.0 && ratio < minDeletedRatio) {
+        LOG.debug("vacuum skipped segId={} ratio={} < threshold={}", segId, ratio, minDeletedRatio);
+        return completedFuture(null);
+      }
+      // Scan vectors
+      Subspace vprefix = new Subspace(indexDirs.segmentsDir().pack(Tuple.from(segStr, "vectors")));
+      Range vr = vprefix.range();
+      return db.readAsync(tr -> tr.getRange(vr).asList())
+          .thenCompose(kvs -> deleteTombstones(db, sk, kvs))
+          .thenCompose(removed -> updateMetaAfterVacuum(db, sk, sm, removed));
+    });
+  }
+
+  private CompletableFuture<Integer> deleteTombstones(
+      Database db, FdbDirectories.SegmentKeys sk, List<KeyValue> kvs) {
+    final long soft = (long) (config.getBuildTxnLimitBytes() * config.getBuildTxnSoftLimitRatio());
+    final int checkEvery = config.getBuildSizeCheckEvery();
+    return deleteSome(db, sk, kvs, 0, 0, checkEvery, soft).thenApply(res -> res.removed);
+  }
+
+  private static final class Res {
+    final int next;
+    final int removed;
+
+    Res(int n, int r) {
+      this.next = n;
+      this.removed = r;
+    }
+  }
+
+  private CompletableFuture<Res> deleteSome(
+      Database db,
+      FdbDirectories.SegmentKeys sk,
+      List<KeyValue> kvs,
+      int j,
+      int removedAcc,
+      int checkEvery,
+      long softLimit) {
+    if (j >= kvs.size()) return completedFuture(new Res(kvs.size(), removedAcc));
+    return db.runAsync(tr -> {
+          int wrote = 0;
+          int removedThis = 0;
+          int i;
+          for (i = j; i < kvs.size(); i++) {
+            KeyValue kv = kvs.get(i);
+            try {
+              VectorRecord rec = VectorRecord.parseFrom(kv.getValue());
+              var tup = indexDirs.segmentsDir().unpack(kv.getKey());
+              int vecId = (int) tup.getLong(tup.size() - 1);
+              if (rec.getDeleted()) {
+                tr.clear(sk.vectorKey(vecId));
+                tr.clear(sk.pqCodeKey(vecId));
+                tr.clear(sk.graphKey(vecId));
+                removedThis++;
+              }
+            } catch (InvalidProtocolBufferException e) {
+              throw new RuntimeException(e);
+            }
+            wrote++;
+            if ((wrote % Math.max(1, checkEvery)) == 0) {
+              Long size = tr.getApproximateSize().join();
+              if (size != null && size >= softLimit) {
+                return completedFuture(new Res(i + 1, removedAcc + removedThis));
+              }
+            }
+          }
+          return completedFuture(new Res(i, removedAcc + removedThis));
+        })
+        .thenCompose(res -> deleteSome(db, sk, kvs, res.next, res.removed, 0, softLimit));
+  }
+
+  private CompletableFuture<Void> updateMetaAfterVacuum(
+      Database db, FdbDirectories.SegmentKeys sk, SegmentMeta sm, int removed) {
+    if (removed <= 0) return completedFuture(null);
+    return db.runAsync(tr -> {
+      SegmentMeta updated = sm.toBuilder()
+          .setDeletedCount(Math.max(0, sm.getDeletedCount() - removed))
+          .build();
+      tr.set(sk.metaKey(), updated.toByteArray());
+      return completedFuture(null);
+    });
+  }
+
+  /**
+   * Compaction skeleton: currently a no-op placeholder that logs intent.
+   *
+   * <p>Future work: merge multiple small sealed segments into a larger target to reclaim
+   * graph/PQ overhead and improve search efficiency.</p>
+   *
+   * @param segIds candidate segments to compact (order/selection policy TBD)
+   * @return a completed future after logging the request
+   */
+  public CompletableFuture<Void> compactSegments(List<Integer> segIds) {
+    LOG.info("Compaction skeleton invoked for segIds={}", segIds);
+    return completedFuture(null);
+  }
+}

--- a/src/main/java/io/github/panghy/vectorsearch/tasks/MaintenanceWorker.java
+++ b/src/main/java/io/github/panghy/vectorsearch/tasks/MaintenanceWorker.java
@@ -1,0 +1,62 @@
+package io.github.panghy.vectorsearch.tasks;
+
+import static java.util.concurrent.CompletableFuture.completedFuture;
+
+import com.apple.foundationdb.Database;
+import io.github.panghy.taskqueue.TaskQueue;
+import io.github.panghy.vectorsearch.config.VectorIndexConfig;
+import io.github.panghy.vectorsearch.fdb.FdbDirectories.IndexDirectories;
+import io.github.panghy.vectorsearch.proto.MaintenanceTask;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Background worker that claims {@link MaintenanceTask} items from the maintenance queue
+ * and executes maintenance operations for a single index namespace.
+ *
+ * <p>Supported task types:
+ * <ul>
+ *   <li><b>Vacuum</b> — removes tombstoned rows from a segment using
+ *       {@link MaintenanceService#vacuumSegment(int, double)}.</li>
+ *   <li><b>Compact</b> — placeholder call to
+ *       {@link MaintenanceService#compactSegments(java.util.List)} for future merges.</li>
+ * </ul>
+ */
+public final class MaintenanceWorker {
+  private final VectorIndexConfig config;
+  private final IndexDirectories indexDirs;
+  private final TaskQueue<String, MaintenanceTask> queue;
+
+  public MaintenanceWorker(VectorIndexConfig cfg, IndexDirectories dirs, TaskQueue<String, MaintenanceTask> queue) {
+    this.config = cfg;
+    this.indexDirs = dirs;
+    this.queue = queue;
+  }
+
+  /**
+   * Claims and processes one maintenance task if available.
+   *
+   * <p>Returns {@code true} if a task was claimed (and completed or failed),
+   * or {@code false} if the queue had no visible tasks. Failures are marked via
+   * {@code claim.fail()} so the queue can retry.</p>
+   */
+  public CompletableFuture<Boolean> runOnce() {
+    Database db = config.getDatabase();
+    return completedFuture(indexDirs)
+        .thenCompose(d -> queue.awaitAndClaimTask(db).thenCompose(claim -> {
+          MaintenanceTask t = claim.task();
+          MaintenanceService svc = new MaintenanceService(config, indexDirs);
+          CompletableFuture<Void> work;
+          if (t.hasVacuum()) {
+            var v = t.getVacuum();
+            work = svc.vacuumSegment(v.getSegId(), v.getMinDeletedRatio());
+          } else if (t.hasCompact()) {
+            work = svc.compactSegments(t.getCompact().getSegIdsList());
+          } else {
+            work = completedFuture(null);
+          }
+          return work.handle((vv, ex) -> ex)
+              .thenCompose(ex -> (ex == null) ? claim.complete() : claim.fail())
+              .thenApply(v -> true);
+        }));
+  }
+}

--- a/src/main/java/io/github/panghy/vectorsearch/tasks/MaintenanceWorkerPool.java
+++ b/src/main/java/io/github/panghy/vectorsearch/tasks/MaintenanceWorkerPool.java
@@ -1,0 +1,75 @@
+package io.github.panghy.vectorsearch.tasks;
+
+import com.apple.foundationdb.async.AsyncUtil;
+import io.github.panghy.taskqueue.TaskQueue;
+import io.github.panghy.vectorsearch.config.VectorIndexConfig;
+import io.github.panghy.vectorsearch.fdb.FdbDirectories;
+import io.github.panghy.vectorsearch.proto.MaintenanceTask;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Runs a small looped pool of {@link MaintenanceWorker} instances to continuously
+ * process maintenance tasks for a given index.
+ *
+ * <p>Lifecycle:
+ * <ul>
+ *   <li>{@link #start(int)} creates N loops, each repeatedly calling {@code runOnce()}.</li>
+ *   <li>{@link #close()} signals shutdown and enqueues sentinel no-op tasks to wake sleepers.</li>
+ * </ul>
+ */
+public final class MaintenanceWorkerPool implements AutoCloseable {
+  private final VectorIndexConfig config;
+  private final FdbDirectories.IndexDirectories indexDirs;
+  private final TaskQueue<String, MaintenanceTask> queue;
+  private final AtomicBoolean running = new AtomicBoolean(false);
+  private final List<CompletableFuture<Void>> loops = new ArrayList<>();
+  private int threadCount = 0;
+  private static final org.slf4j.Logger LOG = org.slf4j.LoggerFactory.getLogger(MaintenanceWorkerPool.class);
+
+  public MaintenanceWorkerPool(
+      VectorIndexConfig cfg, FdbDirectories.IndexDirectories dirs, TaskQueue<String, MaintenanceTask> queue) {
+    this.config = Objects.requireNonNull(cfg);
+    this.indexDirs = Objects.requireNonNull(dirs);
+    this.queue = Objects.requireNonNull(queue);
+  }
+
+  /** Starts {@code n} background worker loops (no-op if {@code n <= 0} or already running). */
+  public synchronized void start(int n) {
+    if (n <= 0 || running.get()) return;
+    running.set(true);
+    threadCount = n;
+    LOG.debug("MaintenanceWorkerPool starting threads={}", n);
+    for (int i = 0; i < n; i++) {
+      MaintenanceWorker worker = new MaintenanceWorker(config, indexDirs, queue);
+      CompletableFuture<Void> loop = AsyncUtil.whileTrue(() -> {
+        if (!running.get()) return CompletableFuture.completedFuture(false);
+        return worker.runOnce().handle((ok, ex) -> true).thenApply(x -> running.get());
+      });
+      loops.add(loop);
+    }
+  }
+
+  /** Stops all worker loops and best-effort wakes sleepers via sentinel tasks. */
+  @Override
+  public synchronized void close() {
+    running.set(false);
+    LOG.debug("MaintenanceWorkerPool stopping; signaling {} sentinel(s)", threadCount);
+    // Enqueue a no-op task as sentinel (vacuum with seg_id < 0) to wake workers
+    try {
+      for (int i = 0; i < threadCount; i++) {
+        String key = "vacuum-segment:-1:shutdown:" + i + ":" + System.nanoTime();
+        MaintenanceTask mt = MaintenanceTask.newBuilder()
+            .setVacuum(
+                MaintenanceTask.Vacuum.newBuilder().setSegId(-1).build())
+            .build();
+        queue.enqueueIfNotExists(key, mt).join();
+      }
+    } catch (Throwable ignored) {
+    }
+    loops.clear();
+  }
+}

--- a/src/main/java/io/github/panghy/vectorsearch/tasks/ProtoSerializers.java
+++ b/src/main/java/io/github/panghy/vectorsearch/tasks/ProtoSerializers.java
@@ -3,6 +3,7 @@ package io.github.panghy.vectorsearch.tasks;
 import com.google.protobuf.ByteString;
 import io.github.panghy.taskqueue.TaskQueueConfig;
 import io.github.panghy.vectorsearch.proto.BuildTask;
+import io.github.panghy.vectorsearch.proto.MaintenanceTask;
 import java.nio.charset.StandardCharsets;
 
 /** Utility TaskQueue serializers for {@link BuildTask} and String keys. */
@@ -46,6 +47,24 @@ public final class ProtoSerializers {
         return bytes == null ? BuildTask.getDefaultInstance() : BuildTask.parseFrom(bytes);
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
         throw new IllegalArgumentException("Failed to parse BuildTask", e);
+      }
+    }
+  }
+
+  /** Protobuf serializer for {@link MaintenanceTask} payloads. */
+  public static final class MaintenanceTaskSerializer implements TaskQueueConfig.TaskSerializer<MaintenanceTask> {
+    @Override
+    public ByteString serialize(MaintenanceTask value) {
+      if (value == null) return ByteString.EMPTY;
+      return value.toByteString();
+    }
+
+    @Override
+    public MaintenanceTask deserialize(ByteString bytes) {
+      try {
+        return bytes == null ? MaintenanceTask.getDefaultInstance() : MaintenanceTask.parseFrom(bytes);
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw new IllegalArgumentException("Failed to parse MaintenanceTask", e);
       }
     }
   }

--- a/src/main/java/io/github/panghy/vectorsearch/tasks/SegmentBuildService.java
+++ b/src/main/java/io/github/panghy/vectorsearch/tasks/SegmentBuildService.java
@@ -201,7 +201,8 @@ public class SegmentBuildService {
       tr.set(sk.graphKey((int) vecId), adj.toByteArray());
       wroteSinceCheck++;
       j++;
-      if ((wroteSinceCheck % checkEvery) == 0) {
+      // Only perform approximate-size checks when a positive cadence is configured.
+      if (checkEvery > 0 && (wroteSinceCheck % checkEvery) == 0) {
         final int jNow = j;
         return tr.getApproximateSize().thenCompose(sz -> {
           if (sz != null && sz >= softLimit) {

--- a/src/main/proto/vectorsearch.proto
+++ b/src/main/proto/vectorsearch.proto
@@ -150,3 +150,26 @@ message BuildTask {
   // Segment id that has been sealed (PENDING) and needs graph/PQ build.
   int32 seg_id = 1;
 }
+
+// -----------------------------------------------------------------------------
+// Maintenance tasks (vacuum, compaction)
+// -----------------------------------------------------------------------------
+// Enqueued out-of-band to reclaim space from tombstoned vectors and (later) merge
+// small segments. Vacuum is safe for v1; compaction is a no-op skeleton for now.
+message MaintenanceTask {
+  oneof task {
+    Vacuum vacuum = 1;
+    Compact compact = 2;
+  }
+
+  message Vacuum {
+    int32 seg_id = 1;
+    // Optional guard: only vacuum if deleted_count / (deleted_count + count) >= threshold.
+    // Use 0 to always vacuum.
+    double min_deleted_ratio = 2;
+  }
+
+  message Compact {
+    repeated int32 seg_ids = 1;
+  }
+}

--- a/src/test/java/io/github/panghy/vectorsearch/api/VectorIndexBatchDeleteIntegrationTest.java
+++ b/src/test/java/io/github/panghy/vectorsearch/api/VectorIndexBatchDeleteIntegrationTest.java
@@ -1,0 +1,113 @@
+package io.github.panghy.vectorsearch.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.apple.foundationdb.Database;
+import com.apple.foundationdb.FDB;
+import com.apple.foundationdb.directory.DirectoryLayer;
+import com.apple.foundationdb.directory.DirectorySubspace;
+import io.github.panghy.taskqueue.TaskQueueConfig;
+import io.github.panghy.taskqueue.TaskQueues;
+import io.github.panghy.vectorsearch.config.VectorIndexConfig;
+import io.github.panghy.vectorsearch.fdb.FdbDirectories;
+import io.github.panghy.vectorsearch.proto.MaintenanceTask;
+import io.github.panghy.vectorsearch.tasks.MaintenanceWorker;
+import io.github.panghy.vectorsearch.tasks.ProtoSerializers;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Integration test for {@link VectorIndex#deleteAll(int[][])}.
+ *
+ * <p>Ensures that batch deletion removes results from query output and that a maintenance
+ * vacuum task can be processed immediately (threshold set to 0.0 for the test).</p>
+ */
+public class VectorIndexBatchDeleteIntegrationTest {
+
+  private Database db;
+  private DirectorySubspace root;
+  private VectorIndex index;
+
+  @BeforeEach
+  public void setup() throws Exception {
+    db = FDB.selectAPIVersion(730).open();
+    root = db.runAsync(tr -> DirectoryLayer.getDefault()
+            .createOrOpen(
+                tr,
+                List.of("vs-delall", UUID.randomUUID().toString()),
+                "vectorsearch".getBytes(StandardCharsets.UTF_8)))
+        .get(5, TimeUnit.SECONDS);
+    VectorIndexConfig cfg = VectorIndexConfig.builder(db, root)
+        .dimension(8)
+        .pqM(4)
+        .pqK(16)
+        .graphDegree(8)
+        .maxSegmentSize(50)
+        .estimatedWorkerCount(1)
+        .defaultTtl(Duration.ofSeconds(30))
+        .vacuumMinDeletedRatio(0.0) // always enqueue after deleteAll
+        .localWorkerThreads(1)
+        .build();
+    index = VectorIndex.createOrOpen(cfg).get(10, TimeUnit.SECONDS);
+  }
+
+  @AfterEach
+  public void teardown() {
+    if (index != null) index.close();
+    if (db != null) {
+      db.run(tr -> {
+        root.remove(tr);
+        return null;
+      });
+      db.close();
+    }
+  }
+
+  @Test
+  public void batchDeleteRemovesAndEnqueuesVacuum() throws Exception {
+    // Insert
+    int[][] ids = new int[12][2];
+    for (int i = 0; i < 12; i++) {
+      float[] v = new float[8];
+      for (int d = 0; d < 8; d++) v[d] = (float) Math.cos(0.01 * i + d);
+      ids[i] = index.add(v, null).get(5, TimeUnit.SECONDS);
+    }
+    // Delete 3 vectors via deleteAll
+    int[][] toDel = new int[][] {ids[2], ids[5], ids[7]};
+    index.deleteAll(toDel).get(5, TimeUnit.SECONDS);
+
+    // Verify they do not appear in results
+    var res = index.query(new float[] {1, 0, 0, 0, 0, 0, 0, 0}, 10).get(5, TimeUnit.SECONDS);
+    for (int[] id : toDel) {
+      assertThat(res.stream().noneMatch(r -> r.segmentId() == id[0] && r.vectorId() == id[1]))
+          .isTrue();
+    }
+
+    // Run a maintenance worker once; with ratio=0.0, vacuum task should be enqueued
+    var dirs = FdbDirectories.openIndex(root, db).get(5, TimeUnit.SECONDS);
+    var maintDir = dirs.tasksDir().createOrOpen(db, List.of("maint")).get(5, TimeUnit.SECONDS);
+    TaskQueueConfig<String, MaintenanceTask> tqc = TaskQueueConfig.builder(
+            db,
+            maintDir,
+            new ProtoSerializers.StringSerializer(),
+            new ProtoSerializers.MaintenanceTaskSerializer())
+        .estimatedWorkerCount(1)
+        .defaultTtl(Duration.ofSeconds(30))
+        .defaultThrottle(Duration.ofMillis(25))
+        .taskNameExtractor(mt ->
+            mt.hasVacuum() ? ("vacuum-segment:" + mt.getVacuum().getSegId()) : "compact")
+        .build();
+    var mq = TaskQueues.createTaskQueue(tqc).get(5, TimeUnit.SECONDS);
+    boolean processed = new MaintenanceWorker(
+            VectorIndexConfig.builder(db, root).dimension(8).build(), dirs, mq)
+        .runOnce()
+        .get(5, TimeUnit.SECONDS);
+    assertThat(processed).isTrue();
+  }
+}

--- a/src/test/java/io/github/panghy/vectorsearch/api/VectorIndexDeleteAndVacuumTest.java
+++ b/src/test/java/io/github/panghy/vectorsearch/api/VectorIndexDeleteAndVacuumTest.java
@@ -1,0 +1,99 @@
+package io.github.panghy.vectorsearch.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.apple.foundationdb.Database;
+import com.apple.foundationdb.FDB;
+import com.apple.foundationdb.directory.DirectoryLayer;
+import com.apple.foundationdb.directory.DirectorySubspace;
+import io.github.panghy.vectorsearch.config.VectorIndexConfig;
+import io.github.panghy.vectorsearch.fdb.FdbDirectories;
+import io.github.panghy.vectorsearch.tasks.MaintenanceService;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/** Integration test for delete API and vacuum maintenance. */
+public class VectorIndexDeleteAndVacuumTest {
+
+  private Database db;
+  private DirectorySubspace root;
+  private VectorIndex index;
+
+  @BeforeEach
+  public void setup() throws Exception {
+    db = FDB.selectAPIVersion(730).open();
+    root = db.runAsync(tr -> DirectoryLayer.getDefault()
+            .createOrOpen(
+                tr,
+                List.of("vs-deltest", UUID.randomUUID().toString()),
+                "vectorsearch".getBytes(StandardCharsets.UTF_8)))
+        .get(5, TimeUnit.SECONDS);
+    VectorIndexConfig cfg = VectorIndexConfig.builder(db, root)
+        .dimension(8)
+        .pqM(4)
+        .pqK(16)
+        .graphDegree(8)
+        .maxSegmentSize(20)
+        .localWorkerThreads(1)
+        .build();
+    index = VectorIndex.createOrOpen(cfg).get(10, TimeUnit.SECONDS);
+  }
+
+  @AfterEach
+  public void teardown() {
+    if (index != null) index.close();
+    if (db != null) {
+      db.run(tr -> {
+        root.remove(tr);
+        return null;
+      });
+      db.close();
+    }
+  }
+
+  @Test
+  public void deleteAndVacuumFlow() throws Exception {
+    // Insert a handful of vectors.
+    int n = 30;
+    int[][] ids = new int[n][2];
+    for (int i = 0; i < n; i++) {
+      float[] v = new float[8];
+      for (int d = 0; d < 8; d++) v[d] = (float) Math.sin(0.01 * i + d);
+      int[] id = index.add(v, null).get(5, TimeUnit.SECONDS);
+      ids[i] = id;
+    }
+
+    // Let builder seal at least one segment
+    Thread.sleep(1000);
+
+    // Delete a few vectors across segments
+    index.delete(ids[0][0], ids[0][1]).get(5, TimeUnit.SECONDS);
+    index.delete(ids[5][0], ids[5][1]).get(5, TimeUnit.SECONDS);
+
+    // Ensure deleted ids are not returned
+    float[] q = new float[] {1f, 0.1f, -0.2f, 0.3f, 0.0f, 0.4f, -0.1f, 0.2f};
+    var results = index.query(q, 10).get(5, TimeUnit.SECONDS);
+    assertThat(results.stream()
+            .noneMatch(r -> (r.segmentId() == ids[0][0] && r.vectorId() == ids[0][1])
+                || (r.segmentId() == ids[5][0] && r.vectorId() == ids[5][1])))
+        .isTrue();
+
+    // Run vacuum directly via service (bypasses queue; validates functionality)
+    var dirs = FdbDirectories.openIndex(root, db).get(5, TimeUnit.SECONDS);
+    var svc = new MaintenanceService(
+        VectorIndexConfig.builder(db, root)
+            .dimension(8)
+            .pqM(4)
+            .pqK(16)
+            .graphDegree(8)
+            .maxSegmentSize(20)
+            .build(),
+        dirs);
+    svc.vacuumSegment(ids[0][0], 0.0).get(5, TimeUnit.SECONDS);
+  }
+}

--- a/src/test/java/io/github/panghy/vectorsearch/fdb/FdbVectorStoreDeleteMetaTest.java
+++ b/src/test/java/io/github/panghy/vectorsearch/fdb/FdbVectorStoreDeleteMetaTest.java
@@ -1,0 +1,120 @@
+package io.github.panghy.vectorsearch.fdb;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.apple.foundationdb.Database;
+import com.apple.foundationdb.FDB;
+import com.apple.foundationdb.directory.DirectoryLayer;
+import com.apple.foundationdb.directory.DirectorySubspace;
+import io.github.panghy.vectorsearch.api.VectorIndex;
+import io.github.panghy.vectorsearch.config.VectorIndexConfig;
+import io.github.panghy.vectorsearch.proto.SegmentMeta;
+import io.github.panghy.vectorsearch.tasks.MaintenanceService;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies that delete operations update {@code SegmentMeta} counters and that
+ * the maintenance vacuum decrements {@code deleted_count} after physically removing rows.
+ */
+public class FdbVectorStoreDeleteMetaTest {
+  private Database db;
+  private DirectorySubspace root;
+  private VectorIndex index;
+
+  @BeforeEach
+  public void setup() throws Exception {
+    db = FDB.selectAPIVersion(730).open();
+    root = db.runAsync(tr -> DirectoryLayer.getDefault()
+            .createOrOpen(
+                tr,
+                List.of("vs-delmeta", UUID.randomUUID().toString()),
+                "vectorsearch".getBytes(StandardCharsets.UTF_8)))
+        .get(5, TimeUnit.SECONDS);
+    VectorIndexConfig cfg = VectorIndexConfig.builder(db, root)
+        .dimension(4)
+        .pqM(2)
+        .pqK(8)
+        .graphDegree(4)
+        .maxSegmentSize(10)
+        .localWorkerThreads(0)
+        .build();
+    index = VectorIndex.createOrOpen(cfg).get(10, TimeUnit.SECONDS);
+  }
+
+  @AfterEach
+  public void teardown() {
+    if (index != null) index.close();
+    if (db != null) {
+      db.run(tr -> {
+        root.remove(tr);
+        return null;
+      });
+      db.close();
+    }
+  }
+
+  @Test
+  public void deleteUpdatesMetaAndVacuumDecrementsDeleted() throws Exception {
+    int[][] ids = new int[3][2];
+    for (int i = 0; i < 3; i++) {
+      float[] v = new float[] {i, i + 1, i + 2, i + 3};
+      ids[i] = index.add(v, null).get(5, TimeUnit.SECONDS);
+    }
+    int seg = ids[0][0];
+    // Before delete
+    var dirs = FdbDirectories.openIndex(root, db).get(5, TimeUnit.SECONDS);
+    SegmentMeta before = db.readAsync(tr -> tr.get(
+                dirs.segmentKeys(String.format("%06d", seg)).metaKey())
+            .thenApply(bytes -> {
+              try {
+                return SegmentMeta.parseFrom(bytes);
+              } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+                throw new RuntimeException(e);
+              }
+            }))
+        .get(5, TimeUnit.SECONDS);
+    assertThat(before.getCount()).isEqualTo(3);
+    assertThat(before.getDeletedCount()).isEqualTo(0);
+
+    // Delete two
+    index.delete(ids[0][0], ids[0][1]).get(5, TimeUnit.SECONDS);
+    index.delete(ids[1][0], ids[1][1]).get(5, TimeUnit.SECONDS);
+
+    SegmentMeta after = db.readAsync(tr -> tr.get(
+                dirs.segmentKeys(String.format("%06d", seg)).metaKey())
+            .thenApply(bytes -> {
+              try {
+                return SegmentMeta.parseFrom(bytes);
+              } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+                throw new RuntimeException(e);
+              }
+            }))
+        .get(5, TimeUnit.SECONDS);
+    assertThat(after.getCount()).isEqualTo(1);
+    assertThat(after.getDeletedCount()).isGreaterThanOrEqualTo(2);
+
+    // Vacuum should reduce deleted_count
+    var svc = new MaintenanceService(
+        VectorIndexConfig.builder(db, root).dimension(4).build(), dirs);
+    svc.vacuumSegment(seg, 0.0).get(5, TimeUnit.SECONDS);
+
+    SegmentMeta postVac = db.readAsync(tr -> tr.get(
+                dirs.segmentKeys(String.format("%06d", seg)).metaKey())
+            .thenApply(bytes -> {
+              try {
+                return SegmentMeta.parseFrom(bytes);
+              } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+                throw new RuntimeException(e);
+              }
+            }))
+        .get(5, TimeUnit.SECONDS);
+    assertThat(postVac.getCount()).isEqualTo(1);
+    assertThat(postVac.getDeletedCount()).isLessThanOrEqualTo(after.getDeletedCount());
+  }
+}

--- a/src/test/java/io/github/panghy/vectorsearch/tasks/MaintenanceServiceTest.java
+++ b/src/test/java/io/github/panghy/vectorsearch/tasks/MaintenanceServiceTest.java
@@ -1,0 +1,56 @@
+package io.github.panghy.vectorsearch.tasks;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import com.apple.foundationdb.Database;
+import com.apple.foundationdb.FDB;
+import com.apple.foundationdb.directory.DirectoryLayer;
+import com.apple.foundationdb.directory.DirectorySubspace;
+import io.github.panghy.vectorsearch.config.VectorIndexConfig;
+import io.github.panghy.vectorsearch.fdb.FdbDirectories;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/** Basic coverage for MaintenanceService threshold and compaction skeleton. */
+public class MaintenanceServiceTest {
+  private Database db;
+  private DirectorySubspace root;
+
+  @BeforeEach
+  public void setup() throws Exception {
+    db = FDB.selectAPIVersion(730).open();
+    root = db.runAsync(tr -> DirectoryLayer.getDefault()
+            .createOrOpen(
+                tr,
+                List.of("vs-mt", UUID.randomUUID().toString()),
+                "vectorsearch".getBytes(StandardCharsets.UTF_8)))
+        .get(5, TimeUnit.SECONDS);
+  }
+
+  @AfterEach
+  public void teardown() {
+    if (db != null) {
+      db.run(tr -> {
+        root.remove(tr);
+        return null;
+      });
+      db.close();
+    }
+  }
+
+  @Test
+  public void thresholdSkipAndCompactionNoop() throws Exception {
+    var dirs = FdbDirectories.openIndex(root, db).get(5, TimeUnit.SECONDS);
+    var svc = new MaintenanceService(
+        VectorIndexConfig.builder(db, root).dimension(4).build(), dirs);
+    // No index initialized; methods should be resilient
+    assertThatCode(() -> svc.vacuumSegment(0, 1.0).get(5, TimeUnit.SECONDS)).doesNotThrowAnyException();
+    assertThatCode(() -> svc.compactSegments(java.util.List.of(0, 1)).get(5, TimeUnit.SECONDS))
+        .doesNotThrowAnyException();
+  }
+}

--- a/src/test/java/io/github/panghy/vectorsearch/tasks/MaintenanceWorkerIntegrationTest.java
+++ b/src/test/java/io/github/panghy/vectorsearch/tasks/MaintenanceWorkerIntegrationTest.java
@@ -1,0 +1,103 @@
+package io.github.panghy.vectorsearch.tasks;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.apple.foundationdb.Database;
+import com.apple.foundationdb.FDB;
+import com.apple.foundationdb.directory.DirectoryLayer;
+import com.apple.foundationdb.directory.DirectorySubspace;
+import io.github.panghy.taskqueue.TaskQueueConfig;
+import io.github.panghy.taskqueue.TaskQueues;
+import io.github.panghy.vectorsearch.api.VectorIndex;
+import io.github.panghy.vectorsearch.config.VectorIndexConfig;
+import io.github.panghy.vectorsearch.fdb.FdbDirectories;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * End-to-end test for {@link io.github.panghy.vectorsearch.tasks.MaintenanceWorker}.
+ *
+ * <p>Scenario: insert a few vectors, delete one, rely on VectorIndex auto-enqueue logic to
+ * schedule a vacuum, then run a worker once against the maintenance queue and assert the task
+ * is processed (no sleeps or polling).</p>
+ */
+public class MaintenanceWorkerIntegrationTest {
+  private Database db;
+  private DirectorySubspace root;
+  private VectorIndex index;
+
+  @BeforeEach
+  public void setup() throws Exception {
+    db = FDB.selectAPIVersion(730).open();
+    root = db.runAsync(tr -> DirectoryLayer.getDefault()
+            .createOrOpen(
+                tr,
+                List.of("vs-mw", UUID.randomUUID().toString()),
+                "vectorsearch".getBytes(StandardCharsets.UTF_8)))
+        .get(5, TimeUnit.SECONDS);
+    VectorIndexConfig cfg = VectorIndexConfig.builder(db, root)
+        .dimension(8)
+        .pqM(4)
+        .pqK(16)
+        .graphDegree(8)
+        .maxSegmentSize(10)
+        .estimatedWorkerCount(1)
+        .defaultTtl(Duration.ofSeconds(30))
+        .localWorkerThreads(1)
+        .vacuumMinDeletedRatio(0.15)
+        .build();
+    index = VectorIndex.createOrOpen(cfg).get(10, TimeUnit.SECONDS);
+  }
+
+  @AfterEach
+  public void teardown() {
+    if (index != null) index.close();
+    if (db != null) {
+      db.run(tr -> {
+        root.remove(tr);
+        return null;
+      });
+      db.close();
+    }
+  }
+
+  @Test
+  public void runsVacuumTask() throws Exception {
+    // Insert few vectors then delete one
+    int[][] ids = new int[5][2];
+    for (int i = 0; i < 5; i++) {
+      float[] v = new float[8];
+      for (int d = 0; d < 8; d++) v[d] = (float) Math.sin(0.02 * i + d);
+      ids[i] = index.add(v, null).get(5, TimeUnit.SECONDS);
+    }
+    index.delete(ids[0][0], ids[0][1]).get(5, TimeUnit.SECONDS);
+
+    // Auto-enqueue from delete should have happened (ratio ~0.2 >= 0.15)
+
+    // Build a dedicated maintenance worker and process exactly one task
+    var dirs = FdbDirectories.openIndex(root, db).get(5, TimeUnit.SECONDS);
+    var maintDir = dirs.tasksDir().createOrOpen(db, List.of("maint")).get(5, TimeUnit.SECONDS);
+    var tqc = TaskQueueConfig.builder(
+            db,
+            maintDir,
+            new ProtoSerializers.StringSerializer(),
+            new ProtoSerializers.MaintenanceTaskSerializer())
+        .estimatedWorkerCount(1)
+        .defaultTtl(Duration.ofSeconds(30))
+        .defaultThrottle(Duration.ofMillis(50))
+        .taskNameExtractor(mt ->
+            mt.hasVacuum() ? ("vacuum-segment:" + mt.getVacuum().getSegId()) : "compact")
+        .build();
+    var mq = TaskQueues.createTaskQueue(tqc).get(5, TimeUnit.SECONDS);
+    MaintenanceWorker worker = new MaintenanceWorker(
+        VectorIndexConfig.builder(db, root).dimension(8).build(), dirs, mq);
+    boolean processed = worker.runOnce().get(5, TimeUnit.SECONDS);
+    assertThat(processed).isTrue();
+  }
+}

--- a/src/test/java/io/github/panghy/vectorsearch/tasks/MaintenanceWorkerPoolTest.java
+++ b/src/test/java/io/github/panghy/vectorsearch/tasks/MaintenanceWorkerPoolTest.java
@@ -1,0 +1,63 @@
+package io.github.panghy.vectorsearch.tasks;
+
+import com.apple.foundationdb.Database;
+import com.apple.foundationdb.FDB;
+import com.apple.foundationdb.directory.DirectoryLayer;
+import io.github.panghy.taskqueue.TaskQueueConfig;
+import io.github.panghy.taskqueue.TaskQueues;
+import io.github.panghy.vectorsearch.config.VectorIndexConfig;
+import io.github.panghy.vectorsearch.fdb.FdbDirectories;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.*;
+
+/**
+ * Lifecycle smoke test for {@link MaintenanceWorkerPool}.
+ *
+ * <p>Verifies that starting and closing the pool does not throw and that sentinel
+ * wake-up logic is exercised without relying on timing.
+ */
+class MaintenanceWorkerPoolTest {
+  Database db;
+  com.apple.foundationdb.directory.DirectorySubspace root;
+
+  @BeforeEach
+  void setup() throws Exception {
+    db = FDB.selectAPIVersion(730).open();
+    root = db.runAsync(tr -> DirectoryLayer.getDefault()
+            .createOrOpen(
+                tr,
+                List.of("vs-mpool", UUID.randomUUID().toString()),
+                "vectorsearch".getBytes(StandardCharsets.UTF_8)))
+        .get(5, TimeUnit.SECONDS);
+  }
+
+  @AfterEach
+  void tearDown() {
+    db.run(tr -> {
+      root.remove(tr);
+      return null;
+    });
+    db.close();
+  }
+
+  @Test
+  void start_and_close() throws Exception {
+    var dirs = FdbDirectories.openIndex(root, db).get(5, TimeUnit.SECONDS);
+    var maintDir = dirs.tasksDir().createOrOpen(db, List.of("maint")).get(5, TimeUnit.SECONDS);
+    var tqc = TaskQueueConfig.builder(
+            db,
+            maintDir,
+            new ProtoSerializers.StringSerializer(),
+            new ProtoSerializers.MaintenanceTaskSerializer())
+        .build();
+    var queue = TaskQueues.createTaskQueue(tqc).get(5, TimeUnit.SECONDS);
+    VectorIndexConfig cfg = VectorIndexConfig.builder(db, root).dimension(4).build();
+
+    MaintenanceWorkerPool pool = new MaintenanceWorkerPool(cfg, dirs, queue);
+    pool.start(1);
+    pool.close();
+  }
+}

--- a/src/test/java/io/github/panghy/vectorsearch/tasks/ProtoSerializersTest.java
+++ b/src/test/java/io/github/panghy/vectorsearch/tasks/ProtoSerializersTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.protobuf.ByteString;
 import io.github.panghy.vectorsearch.proto.BuildTask;
+import io.github.panghy.vectorsearch.proto.MaintenanceTask;
 import org.junit.jupiter.api.Test;
 
 class ProtoSerializersTest {
@@ -38,5 +39,24 @@ class ProtoSerializersTest {
     assertThat(bs.serialize(null)).isEqualTo(EMPTY);
     // null -> default instance
     assertThat(bs.deserialize(null)).isEqualTo(BuildTask.getDefaultInstance());
+
+    ProtoSerializers.MaintenanceTaskSerializer ms = new ProtoSerializers.MaintenanceTaskSerializer();
+    assertThat(ms.serialize(null)).isEqualTo(EMPTY);
+    assertThat(ms.deserialize(null)).isEqualTo(MaintenanceTask.getDefaultInstance());
+  }
+
+  @Test
+  void maintenance_task_serializer_round_trip() {
+    ProtoSerializers.MaintenanceTaskSerializer s = new ProtoSerializers.MaintenanceTaskSerializer();
+    MaintenanceTask t = MaintenanceTask.newBuilder()
+        .setVacuum(MaintenanceTask.Vacuum.newBuilder()
+            .setSegId(7)
+            .setMinDeletedRatio(0.2)
+            .build())
+        .build();
+    ByteString bs = s.serialize(t);
+    MaintenanceTask back = s.deserialize(bs);
+    assertThat(back.hasVacuum()).isTrue();
+    assertThat(back.getVacuum().getSegId()).isEqualTo(7);
   }
 }


### PR DESCRIPTION
Summary
- Add delete(int segId, int vecId) and deleteAll(int[][]) to VectorIndex with per-segment auto-enqueue of vacuum when deleted_ratio >= config.vacuumMinDeletedRatio (default 0.25). 
- Introduce MaintenanceTask proto + MaintenanceService (vacuum), MaintenanceWorker, and MaintenanceWorkerPool. 
- Wire a dedicated maintenance queue under tasks/maint; optional localMaintenanceWorkerThreads. 
- Refactor VectorIndex.createOrOpen(): extract createBuildQueue/createMaintenanceQueue helpers. 
- Fix SegmentBuildService modulo guard (avoid / by zero when skipping size checks). 
- Add tests: batch delete, delete+vacuum, maintenance worker/pool, serializers; update docs/comments throughout.

Details
- Vacuum physically deletes tombstoned vector, PQ code, adjacency; decrements deleted_count; chunked by approximate txn size. 
- Auto-enqueue runs only after deletes (no periodic sweeper). 
- Config knob vacuumMinDeletedRatio, default 0.25; set to 0.0 to always enqueue.

Validation
- ./gradlew clean build passes locally with coverage thresholds. 
- Integration tests exercise deleteAll path and worker runOnce without sleeps.

Follow-ups
- Expose lightweight admin accessor to list segments + ratios for ops dashboards. 
- Optional cooldown to throttle repeated vacuum enqueues per segment. 
- Compaction implementation (skeleton present).