### PR TITLE
Add global task queue support for distributed workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,9 +162,7 @@ Background compactions are planned from small SEALED segments and throttled by `
 - Programmatic vacuum:
   - Use `MaintenanceService.vacuumSegment(segId, minDeletedRatio)` to run a targeted vacuum now.
   - Or enqueue and process via the maintenance queue using `MaintenanceWorker`.
-  - Example:`var dirs = FdbDirectories.openIndex(root, db).get(5, TimeUnit.SECONDS);
-var svc = new MaintenanceService(cfg, dirs);
-svc.vacuumSegment(0 /* segId */, 0.0 /* minDeletedRatio */).get(10, TimeUnit.SECONDS);`
+  - Example:`var dirs = FdbDirectories.openIndex(root, db).get(5, TimeUnit.SECONDS); var svc = new MaintenanceService(cfg, dirs); svc.vacuumSegment(0 /* segId */, 0.0 /* minDeletedRatio */).get(10, TimeUnit.SECONDS);`
 - Background processing:
   - Set `localMaintenanceWorkerThreads > 0` to auto‑start a maintenance worker pool, or use `new MaintenanceWorker(cfg, dirs, queue).runOnce()` against the `tasks/maint` queue.
 

--- a/README.md
+++ b/README.md
@@ -11,9 +11,11 @@ A Java vector search library built on FoundationDB with per-segment DiskANN-styl
 - Async Caffeine caches for PQ codebooks and adjacency; optional prefetch
 - OpenTelemetry metrics for caches and segment states
 - Maintenance: tombstone delete APIs and cooldown-aware vacuuming
+- Global task queue support for centralized background workers across multiple indices
 - 90%+ line / 75%+ branch coverage (JaCoCo gates)
 
 Implementation notes
+
 - Segment registry: the index maintains a compact `segmentsIndex` range under the index root to list existing segments efficiently. Queries list segments from this registry; there is no legacy per‑meta scan fallback.
 - Builder invariants: only PENDING and WRITING segments are sealed by the builder; ACTIVE segments are never sealed directly.
 
@@ -62,12 +64,12 @@ index.close();
 - Search: SEALED (and COMPACTING sources) use PQ/graph traversal + exact re-rank; ACTIVE/PENDING use brute-force. WRITING segments are ignored by search.
 - Maintenance: Deletes set a tombstone flag and updates counters. If the deleted ratio exceeds a threshold, the index enqueues a vacuum maintenance task (with a configurable cooldown). Vacuum physically removes vector, PQ code, and adjacency, and decrements `deleted_count` while stamping `last_vacuum_at_ms`.
 
-
 ## Telemetry (OpenTelemetry)
 
 This library emits OpenTelemetry metrics and spans. It uses the global OpenTelemetry SDK (GlobalOpenTelemetry), so you can plug any exporter (OTLP/Prometheus/etc.) without code changes.
 
 Metrics (histograms are in milliseconds):
+
 - vectorsearch.query.duration_ms (histogram)
 - vectorsearch.query.count (counter)
 - vectorsearch.build.duration_ms (histogram)
@@ -79,15 +81,18 @@ Metrics (histograms are in milliseconds):
 - vectorsearch.compaction.run (counter)
 
 Common attributes on spans and metrics:
+
 - index.path: user‑readable DirectorySubspace path of the index (e.g. indexes/myIndex)
 - metric, dim, k (queries)
 - segId (vacuum/build)
 - anchorSegId (compaction)
 
 Spans:
+
 - vectorsearch.query, vectorsearch.build, vectorsearch.vacuum, vectorsearch.compaction
 
 Enablement:
+
 - Provide a GlobalOpenTelemetry instance in your app initialization with your preferred exporter. If none is provided, no‑op SDK is used and metrics/spans are dropped.
 
 ## Build, Test, and Coverage
@@ -136,12 +141,14 @@ Pure-CPU benchmarks for hot-path operations. No FDB or Docker required.
 ## Configuration (high-level)
 
 VectorIndexConfig includes:
+
 - `dimension`, `metric` (L2 or COSINE)
 - `maxSegmentSize`, `graphDegree`, `pqM`, `pqK`
 - `oversample` (merge fan-in), `localWorkerThreads` (auto-start builders)
 - `vacuumMinDeletedRatio`, `vacuumCooldown(Duration)` for maintenance behavior
 - `codebookBatchLoadSize`, `adjacencyBatchLoadSize` (async cache loaders)
 - `prefetchCodebooksEnabled` (default true) and `prefetchCodebooksSync` (test‑only; block query until codebook prefetch completes for sealed segments)
+- `globalTaskQueueConfig(GlobalTaskQueueConfig)` for routing build/maintenance tasks to shared global queues
 
 See `src/main/java/.../VectorIndexConfig.java` for the full builder.
 
@@ -155,18 +162,83 @@ Background compactions are planned from small SEALED segments and throttled by `
 - Programmatic vacuum:
   - Use `MaintenanceService.vacuumSegment(segId, minDeletedRatio)` to run a targeted vacuum now.
   - Or enqueue and process via the maintenance queue using `MaintenanceWorker`.
-  - Example:
-    ```java
-    var dirs = FdbDirectories.openIndex(root, db).get(5, TimeUnit.SECONDS);
-    var svc = new MaintenanceService(cfg, dirs);
-    svc.vacuumSegment(0 /* segId */, 0.0 /* minDeletedRatio */).get(10, TimeUnit.SECONDS);
-    ```
+  - Example:`var dirs = FdbDirectories.openIndex(root, db).get(5, TimeUnit.SECONDS);
+var svc = new MaintenanceService(cfg, dirs);
+svc.vacuumSegment(0 /* segId */, 0.0 /* minDeletedRatio */).get(10, TimeUnit.SECONDS);`
 - Background processing:
   - Set `localMaintenanceWorkerThreads > 0` to auto‑start a maintenance worker pool, or use `new MaintenanceWorker(cfg, dirs, queue).runOnce()` against the `tasks/maint` queue.
 
+## Global Task Queue
+
+The global task queue allows background workers (build and maintenance) to run in a separate process, servicing multiple vector indices from a single shared pool. When enabled on an index, local task queues and workers are not used. This is useful for multi-index deployments or when you want to run worker processes separately from query-serving processes.
+
+### Setup
+
+Create global queue directories and configure an index to use them:
+
+```java
+// Create global queue directories
+DirectorySubspace globalDir = db.runAsync(tr -> DirectoryLayer.getDefault()
+    .createOrOpen(tr, List.of("myapp", "global-queues")))
+    .get(5, TimeUnit.SECONDS);
+
+DirectorySubspace buildDir = globalDir.createOrOpen(db, List.of("build")).get(5, TimeUnit.SECONDS);
+DirectorySubspace maintDir = globalDir.createOrOpen(db, List.of("maint")).get(5, TimeUnit.SECONDS);
+
+// Create task queues
+TaskQueue<String, GlobalBuildTask> globalBuildQueue = TaskQueues.createTaskQueue(
+    TaskQueueConfig.builder(db, buildDir,
+        new ProtoSerializers.StringSerializer(),
+        new ProtoSerializers.GlobalBuildTaskSerializer())
+    .build()).get(5, TimeUnit.SECONDS);
+
+TaskQueue<String, GlobalMaintenanceTask> globalMaintQueue = TaskQueues.createTaskQueue(
+    TaskQueueConfig.builder(db, maintDir,
+        new ProtoSerializers.StringSerializer(),
+        new ProtoSerializers.GlobalMaintenanceTaskSerializer())
+    .build()).get(5, TimeUnit.SECONDS);
+
+// Configure index with global queues (no local workers)
+GlobalTaskQueueConfig globalCfg = new GlobalTaskQueueConfig(globalBuildQueue, globalMaintQueue);
+VectorIndexConfig cfg = VectorIndexConfig.builder(db, indexDir)
+    .dimension(8)
+    .globalTaskQueueConfig(globalCfg)
+    .build();
+VectorIndex index = VectorIndex.createOrOpen(cfg).get(10, TimeUnit.SECONDS);
+```
+
+### Running Global Workers
+
+Use `GlobalWorkerRunner` to start shared worker threads that process tasks from the global queues:
+
+```java
+// Template config for operational settings (data params read from each index's persisted IndexMeta)
+VectorIndexConfig templateConfig = VectorIndexConfig.builder(db, dummyDir)
+    .dimension(1) // overridden per-index from IndexMeta
+    .buildTxnLimitBytes(5_000_000)
+    .maxConcurrentCompactions(2)
+    .build();
+
+// Start workers: 4 build threads + 2 maintenance threads
+GlobalWorkerRunner runner = new GlobalWorkerRunner(db, globalCfg, templateConfig, 4, 2);
+runner.start();
+
+// ... later
+runner.close(); // graceful shutdown
+```
+
+### Key Points
+
+- Separate queues for build and maintenance tasks
+- Multiple indices can share the same global queues
+- Data-format params (dimension, metric, pqM, pqK, graphDegree, etc.) are read from each index's persisted `IndexMeta`
+- Operational params (compaction knobs, vacuum thresholds, txn limits) come from a uniform template config
+- Backward compatible — existing behavior is unchanged when `globalTaskQueueConfig` is not set
+- `awaitIndexingComplete()` waits for ALL global build tasks (not just the calling index's)
+
 ## Design Highlights
 
- - DirectoryLayer layout per index: `meta`, `currentSegment`, `segmentsIndex/<segId>`, `segments/<segId>/{meta,vectors/,pq/{codebook,codes/},graph/}`, `tasks/`, and `gid/{map,rev}` for global id mapping.
+- DirectoryLayer layout per index: `meta`, `currentSegment`, `segmentsIndex/<segId>`, `segments/<segId>/{meta,vectors/,pq/{codebook,codes/},graph/}`, `tasks/`, and `gid/{map,rev}` for global id mapping.
 - Async batched I/O with transaction size guards (FDB 10MB/5s)
 - Caffeine AsyncLoadingCache with bulk loaders, optional prefetch for codebooks
 - Deterministic seeding and auto‑tuning for BEST_FIRST traversal

--- a/README.md
+++ b/README.md
@@ -162,7 +162,13 @@ Background compactions are planned from small SEALED segments and throttled by `
 - Programmatic vacuum:
   - Use `MaintenanceService.vacuumSegment(segId, minDeletedRatio)` to run a targeted vacuum now.
   - Or enqueue and process via the maintenance queue using `MaintenanceWorker`.
-  - Example:`var dirs = FdbDirectories.openIndex(root, db).get(5, TimeUnit.SECONDS); var svc = new MaintenanceService(cfg, dirs); svc.vacuumSegment(0 /* segId */, 0.0 /* minDeletedRatio */).get(10, TimeUnit.SECONDS);`
+  - Example:
+
+    ```java
+    var dirs = FdbDirectories.openIndex(root, db).get(5, TimeUnit.SECONDS);
+    var svc = new MaintenanceService(cfg, dirs);
+    svc.vacuumSegment(0 /* segId */, 0.0 /* minDeletedRatio */).get(10, TimeUnit.SECONDS);
+    ```
 - Background processing:
   - Set `localMaintenanceWorkerThreads > 0` to auto‑start a maintenance worker pool, or use `new MaintenanceWorker(cfg, dirs, queue).runOnce()` against the `tasks/maint` queue.
 

--- a/README.md
+++ b/README.md
@@ -210,16 +210,15 @@ VectorIndex index = VectorIndex.createOrOpen(cfg).get(10, TimeUnit.SECONDS);
 Use `GlobalWorkerRunner` to start shared worker threads that process tasks from the global queues:
 
 ```java
-// Template config for operational settings (data params read from each index's persisted IndexMeta)
-VectorIndexConfig templateConfig = VectorIndexConfig.builder(db, dummyDir)
-    .dimension(1) // overridden per-index from IndexMeta
+// Operational settings for all indices processed by this runner
+WorkerConfig workerConfig = WorkerConfig.builder()
     .buildTxnLimitBytes(5_000_000)
     .maxConcurrentCompactions(2)
     .build();
 
 // Start workers: 4 build threads + 2 maintenance threads
-GlobalWorkerRunner runner = new GlobalWorkerRunner(db, globalCfg, templateConfig, 4, 2);
-runner.start();
+GlobalWorkerRunner runner = new GlobalWorkerRunner(db, workerConfig, globalCfg);
+runner.start(4, 2);
 
 // ... later
 runner.close(); // graceful shutdown

--- a/src/main/java/io/github/panghy/vectorsearch/config/GlobalTaskQueueConfig.java
+++ b/src/main/java/io/github/panghy/vectorsearch/config/GlobalTaskQueueConfig.java
@@ -1,0 +1,48 @@
+package io.github.panghy.vectorsearch.config;
+
+import io.github.panghy.taskqueue.TaskQueue;
+import io.github.panghy.vectorsearch.proto.GlobalBuildTask;
+import io.github.panghy.vectorsearch.proto.GlobalMaintenanceTask;
+import java.util.Objects;
+
+/**
+ * Immutable holder for global (cross-index) task queues.
+ *
+ * <p>When supplied to {@link VectorIndexConfig}, it signals that the index should enqueue
+ * build and maintenance tasks into these shared queues instead of creating per-index local
+ * queues and workers.</p>
+ *
+ * @see VectorIndexConfig#getGlobalTaskQueueConfig()
+ * @see VectorIndexConfig#isGlobalTaskQueueEnabled()
+ */
+public final class GlobalTaskQueueConfig {
+
+  private final TaskQueue<String, GlobalBuildTask> buildQueue;
+  private final TaskQueue<String, GlobalMaintenanceTask> maintenanceQueue;
+
+  /**
+   * Creates a new {@code GlobalTaskQueueConfig}.
+   *
+   * @param buildQueue       the shared build task queue (must not be null)
+   * @param maintenanceQueue the shared maintenance task queue (must not be null)
+   */
+  public GlobalTaskQueueConfig(
+      TaskQueue<String, GlobalBuildTask> buildQueue, TaskQueue<String, GlobalMaintenanceTask> maintenanceQueue) {
+    this.buildQueue = Objects.requireNonNull(buildQueue, "buildQueue must not be null");
+    this.maintenanceQueue = Objects.requireNonNull(maintenanceQueue, "maintenanceQueue must not be null");
+  }
+
+  /**
+   * Returns the global build task queue.
+   */
+  public TaskQueue<String, GlobalBuildTask> getBuildQueue() {
+    return buildQueue;
+  }
+
+  /**
+   * Returns the global maintenance task queue.
+   */
+  public TaskQueue<String, GlobalMaintenanceTask> getMaintenanceQueue() {
+    return maintenanceQueue;
+  }
+}

--- a/src/main/java/io/github/panghy/vectorsearch/config/VectorIndexConfig.java
+++ b/src/main/java/io/github/panghy/vectorsearch/config/VectorIndexConfig.java
@@ -84,10 +84,12 @@ public final class VectorIndexConfig {
         throw new IllegalArgumentException("estimatedWorkerCount must be positive");
       if (b.maxConcurrentCompactions < 0)
         throw new IllegalArgumentException("maxConcurrentCompactions must be >= 0");
+      Objects.requireNonNull(b.vacuumCooldown, "vacuumCooldown must not be null");
       if (b.vacuumCooldown.isNegative()) throw new IllegalArgumentException("vacuumCooldown must be >= 0");
       if (!(b.vacuumMinDeletedRatio >= 0.0 && b.vacuumMinDeletedRatio <= 1.0))
         throw new IllegalArgumentException("vacuumMinDeletedRatio must be in [0,1]");
       requirePositive(b.defaultTtl, "defaultTtl");
+      Objects.requireNonNull(b.defaultThrottle, "defaultThrottle must not be null");
       if (b.defaultThrottle.isNegative())
         throw new IllegalArgumentException("defaultThrottle must not be negative");
       Objects.requireNonNull(b.instantSource, "instantSource must not be null");

--- a/src/main/java/io/github/panghy/vectorsearch/config/VectorIndexConfig.java
+++ b/src/main/java/io/github/panghy/vectorsearch/config/VectorIndexConfig.java
@@ -36,36 +36,11 @@ public final class VectorIndexConfig {
   private final int graphBuildBreadth;
   private final double graphAlpha;
 
-  private final int estimatedWorkerCount;
   private final int localWorkerThreads;
   private final int localMaintenanceWorkerThreads;
-  private final int maxConcurrentCompactions;
-  private final Duration vacuumCooldown;
-  private final double vacuumMinDeletedRatio;
-  private final Duration defaultTtl;
-  private final Duration defaultThrottle;
-  private final InstantSource instantSource;
 
-  // Batch sizes for async cache bulk loads
-  private final int codebookBatchLoadSize;
-  private final int adjacencyBatchLoadSize;
-  private final Map<String, String> metricAttributes;
-  private final boolean prefetchCodebooksEnabled;
-  private final boolean prefetchCodebooksSync;
-  private final boolean autoFindCompactionCandidates;
-
-  // Compaction planner knobs
-  private final int compactionMinSegments;
-  private final int compactionMaxSegments;
-  private final double compactionMinFragmentation;
-  private final double compactionAgeBiasWeight;
-  private final double compactionSizeBiasWeight;
-  private final double compactionFragBiasWeight;
-
-  // Build batching/size control
-  private final long buildTxnLimitBytes;
-  private final double buildTxnSoftLimitRatio;
-  private final int buildSizeCheckEvery;
+  // All operational settings are delegated to WorkerConfig
+  private final WorkerConfig workerConfig;
 
   // Optional global task queue config
   private final GlobalTaskQueueConfig globalTaskQueueConfig;
@@ -94,62 +69,80 @@ public final class VectorIndexConfig {
     if (b.oversample <= 0) throw new IllegalArgumentException("oversample must be positive");
     this.oversample = b.oversample;
 
-    if (b.estimatedWorkerCount <= 0) throw new IllegalArgumentException("estimatedWorkerCount must be positive");
-    this.estimatedWorkerCount = b.estimatedWorkerCount;
     if (b.localWorkerThreads < 0) throw new IllegalArgumentException("localWorkerThreads must be >= 0");
     this.localWorkerThreads = b.localWorkerThreads;
     if (b.localMaintenanceWorkerThreads < 0)
       throw new IllegalArgumentException("localMaintenanceWorkerThreads must be >= 0");
     this.localMaintenanceWorkerThreads = b.localMaintenanceWorkerThreads;
-    if (b.maxConcurrentCompactions < 0) throw new IllegalArgumentException("maxConcurrentCompactions must be >= 0");
-    this.maxConcurrentCompactions = b.maxConcurrentCompactions;
-    if (b.vacuumCooldown.isNegative()) throw new IllegalArgumentException("vacuumCooldown must be >= 0");
-    this.vacuumCooldown = b.vacuumCooldown;
-    if (!(b.vacuumMinDeletedRatio >= 0.0 && b.vacuumMinDeletedRatio <= 1.0))
-      throw new IllegalArgumentException("vacuumMinDeletedRatio must be in [0,1]");
-    this.vacuumMinDeletedRatio = b.vacuumMinDeletedRatio;
 
-    this.defaultTtl = requirePositive(b.defaultTtl, "defaultTtl");
-    if (b.defaultThrottle.isNegative()) {
-      throw new IllegalArgumentException("defaultThrottle must not be negative");
+    // Build or use the provided WorkerConfig for all operational settings
+    if (b.workerConfig != null) {
+      this.workerConfig = b.workerConfig;
+    } else {
+      // Validate operational fields before building WorkerConfig
+      if (b.estimatedWorkerCount <= 0)
+        throw new IllegalArgumentException("estimatedWorkerCount must be positive");
+      if (b.maxConcurrentCompactions < 0)
+        throw new IllegalArgumentException("maxConcurrentCompactions must be >= 0");
+      if (b.vacuumCooldown.isNegative()) throw new IllegalArgumentException("vacuumCooldown must be >= 0");
+      if (!(b.vacuumMinDeletedRatio >= 0.0 && b.vacuumMinDeletedRatio <= 1.0))
+        throw new IllegalArgumentException("vacuumMinDeletedRatio must be in [0,1]");
+      requirePositive(b.defaultTtl, "defaultTtl");
+      if (b.defaultThrottle.isNegative())
+        throw new IllegalArgumentException("defaultThrottle must not be negative");
+      Objects.requireNonNull(b.instantSource, "instantSource must not be null");
+      if (b.codebookBatchLoadSize <= 0)
+        throw new IllegalArgumentException("codebookBatchLoadSize must be positive");
+      if (b.adjacencyBatchLoadSize <= 0)
+        throw new IllegalArgumentException("adjacencyBatchLoadSize must be positive");
+      if (b.compactionMinSegments < 2) throw new IllegalArgumentException("compactionMinSegments must be >= 2");
+      if (b.compactionMaxSegments < b.compactionMinSegments)
+        throw new IllegalArgumentException("compactionMaxSegments must be >= compactionMinSegments");
+      if (!(b.compactionMinFragmentation >= 0.0 && b.compactionMinFragmentation <= 1.0))
+        throw new IllegalArgumentException("compactionMinFragmentation must be in [0,1]");
+      if (b.compactionAgeBiasWeight < 0.0)
+        throw new IllegalArgumentException("compactionAgeBiasWeight must be >= 0");
+      if (b.compactionSizeBiasWeight < 0.0)
+        throw new IllegalArgumentException("compactionSizeBiasWeight must be >= 0");
+      if (b.compactionFragBiasWeight < 0.0)
+        throw new IllegalArgumentException("compactionFragBiasWeight must be >= 0");
+      if (b.buildTxnLimitBytes <= 0) throw new IllegalArgumentException("buildTxnLimitBytes must be positive");
+      if (!(b.buildTxnSoftLimitRatio > 0.0 && b.buildTxnSoftLimitRatio < 1.0))
+        throw new IllegalArgumentException("buildTxnSoftLimitRatio must be in (0,1)");
+      if (b.buildSizeCheckEvery <= 0) throw new IllegalArgumentException("buildSizeCheckEvery must be positive");
+
+      this.workerConfig = WorkerConfig.builder()
+          .estimatedWorkerCount(b.estimatedWorkerCount)
+          .defaultTtl(b.defaultTtl)
+          .defaultThrottle(b.defaultThrottle)
+          .maxConcurrentCompactions(b.maxConcurrentCompactions)
+          .buildTxnLimitBytes(b.buildTxnLimitBytes)
+          .buildTxnSoftLimitRatio(b.buildTxnSoftLimitRatio)
+          .buildSizeCheckEvery(b.buildSizeCheckEvery)
+          .vacuumCooldown(b.vacuumCooldown)
+          .vacuumMinDeletedRatio(b.vacuumMinDeletedRatio)
+          .autoFindCompactionCandidates(b.autoFindCompactionCandidates)
+          .compactionMinSegments(b.compactionMinSegments)
+          .compactionMaxSegments(b.compactionMaxSegments)
+          .compactionMinFragmentation(b.compactionMinFragmentation)
+          .compactionAgeBiasWeight(b.compactionAgeBiasWeight)
+          .compactionSizeBiasWeight(b.compactionSizeBiasWeight)
+          .compactionFragBiasWeight(b.compactionFragBiasWeight)
+          .codebookBatchLoadSize(b.codebookBatchLoadSize)
+          .adjacencyBatchLoadSize(b.adjacencyBatchLoadSize)
+          .prefetchCodebooksEnabled(b.prefetchCodebooksEnabled)
+          .prefetchCodebooksSync(b.prefetchCodebooksSync)
+          .instantSource(b.instantSource)
+          .metricAttributes(b.metricAttributes)
+          .defaultMaxSegmentSize(b.maxSegmentSize)
+          .defaultPqM(b.pqM)
+          .defaultPqK(b.pqK)
+          .defaultGraphDegree(b.graphDegree)
+          .defaultOversample(b.oversample)
+          .defaultGraphBuildBreadth(b.graphBuildBreadth)
+          .defaultGraphAlpha(b.graphAlpha)
+          .build();
     }
-    this.defaultThrottle = b.defaultThrottle;
-    this.instantSource = Objects.requireNonNull(b.instantSource, "instantSource must not be null");
-
-    if (b.codebookBatchLoadSize <= 0) throw new IllegalArgumentException("codebookBatchLoadSize must be positive");
-    if (b.adjacencyBatchLoadSize <= 0)
-      throw new IllegalArgumentException("adjacencyBatchLoadSize must be positive");
-    this.codebookBatchLoadSize = b.codebookBatchLoadSize;
-    this.adjacencyBatchLoadSize = b.adjacencyBatchLoadSize;
-    this.metricAttributes = Map.copyOf(b.metricAttributes);
-    this.prefetchCodebooksEnabled = b.prefetchCodebooksEnabled;
-    this.prefetchCodebooksSync = b.prefetchCodebooksSync;
-    this.autoFindCompactionCandidates = b.autoFindCompactionCandidates;
-
-    if (b.compactionMinSegments < 2) throw new IllegalArgumentException("compactionMinSegments must be >= 2");
-    this.compactionMinSegments = b.compactionMinSegments;
-    if (b.compactionMaxSegments < b.compactionMinSegments)
-      throw new IllegalArgumentException("compactionMaxSegments must be >= compactionMinSegments");
-    this.compactionMaxSegments = b.compactionMaxSegments;
-    if (!(b.compactionMinFragmentation >= 0.0 && b.compactionMinFragmentation <= 1.0))
-      throw new IllegalArgumentException("compactionMinFragmentation must be in [0,1]");
-    this.compactionMinFragmentation = b.compactionMinFragmentation;
-    if (b.compactionAgeBiasWeight < 0.0) throw new IllegalArgumentException("compactionAgeBiasWeight must be >= 0");
-    this.compactionAgeBiasWeight = b.compactionAgeBiasWeight;
-    if (b.compactionSizeBiasWeight < 0.0)
-      throw new IllegalArgumentException("compactionSizeBiasWeight must be >= 0");
-    this.compactionSizeBiasWeight = b.compactionSizeBiasWeight;
-    if (b.compactionFragBiasWeight < 0.0)
-      throw new IllegalArgumentException("compactionFragBiasWeight must be >= 0");
-    this.compactionFragBiasWeight = b.compactionFragBiasWeight;
-
-    if (b.buildTxnLimitBytes <= 0) throw new IllegalArgumentException("buildTxnLimitBytes must be positive");
-    if (!(b.buildTxnSoftLimitRatio > 0.0 && b.buildTxnSoftLimitRatio < 1.0))
-      throw new IllegalArgumentException("buildTxnSoftLimitRatio must be in (0,1)");
-    if (b.buildSizeCheckEvery <= 0) throw new IllegalArgumentException("buildSizeCheckEvery must be positive");
-    this.buildTxnLimitBytes = b.buildTxnLimitBytes;
-    this.buildTxnSoftLimitRatio = b.buildTxnSoftLimitRatio;
-    this.buildSizeCheckEvery = b.buildSizeCheckEvery;
 
     this.globalTaskQueueConfig = b.globalTaskQueueConfig; // nullable
   }
@@ -234,158 +227,132 @@ public final class VectorIndexConfig {
   }
 
   /**
-   * Returns the estimated number of background workers.
+   * Returns the {@link WorkerConfig} holding all operational settings.
    */
-  public int getEstimatedWorkerCount() {
-    return estimatedWorkerCount;
+  public WorkerConfig getWorkerConfig() {
+    return workerConfig;
   }
 
-  /**
-   * Returns the number of local worker threads to auto-start.
-   */
+  /** Returns the estimated number of background workers. */
+  public int getEstimatedWorkerCount() {
+    return workerConfig.getEstimatedWorkerCount();
+  }
+
+  /** Returns the number of local worker threads to auto-start. */
   public int getLocalWorkerThreads() {
     return localWorkerThreads;
   }
 
-  /**
-   * Returns the number of local maintenance worker threads to auto-start.
-   */
+  /** Returns the number of local maintenance worker threads to auto-start. */
   public int getLocalMaintenanceWorkerThreads() {
     return localMaintenanceWorkerThreads;
   }
 
   /** Maximum number of in-flight compactions per index. */
   public int getMaxConcurrentCompactions() {
-    return maxConcurrentCompactions;
+    return workerConfig.getMaxConcurrentCompactions();
   }
+
   /** Returns the cooldown between repeated vacuum enqueues for the same segment. */
   public Duration getVacuumCooldown() {
-    return vacuumCooldown;
+    return workerConfig.getVacuumCooldown();
   }
 
   /**
    * Minimum deleted ratio [0, 1] that triggers auto-enqueue of a vacuum task after deletes.
-   *
-   * <p>Example: 0.25 means enqueue a threshold-aware vacuum when at least 25% of a segment's
-   * rows are tombstoned. Use 0.0 to enqueue immediately; 1.0 to effectively disable.</p>
    */
   public double getVacuumMinDeletedRatio() {
-    return vacuumMinDeletedRatio;
+    return workerConfig.getVacuumMinDeletedRatio();
   }
 
-  /**
-   * Returns the default claim TTL used by background tasks.
-   */
+  /** Returns the default claim TTL used by background tasks. */
   public Duration getDefaultTtl() {
-    return defaultTtl;
+    return workerConfig.getDefaultTtl();
   }
 
-  /**
-   * Returns the default throttle between tasks for the same key.
-   */
+  /** Returns the default throttle between tasks for the same key. */
   public Duration getDefaultThrottle() {
-    return defaultThrottle;
+    return workerConfig.getDefaultThrottle();
   }
 
-  /**
-   * Returns the time source (injectable for tests).
-   */
+  /** Returns the time source (injectable for tests). */
   public InstantSource getInstantSource() {
-    return instantSource;
+    return workerConfig.getInstantSource();
   }
 
-  /**
-   * Returns batch size for async codebook bulk loads.
-   */
+  /** Returns batch size for async codebook bulk loads. */
   public int getCodebookBatchLoadSize() {
-    return codebookBatchLoadSize;
+    return workerConfig.getCodebookBatchLoadSize();
   }
 
-  /**
-   * Returns batch size for async adjacency bulk loads.
-   */
+  /** Returns batch size for async adjacency bulk loads. */
   public int getAdjacencyBatchLoadSize() {
-    return adjacencyBatchLoadSize;
+    return workerConfig.getAdjacencyBatchLoadSize();
   }
 
-  /**
-   * Additional metric attributes to add to emitted metrics/spans.
-   */
+  /** Additional metric attributes to add to emitted metrics/spans. */
   public Map<String, String> getMetricAttributes() {
-    return metricAttributes;
+    return workerConfig.getMetricAttributes();
   }
 
-  /**
-   * Returns whether query-time codebook prefetch is enabled.
-   */
+  /** Returns whether query-time codebook prefetch is enabled. */
   public boolean isPrefetchCodebooksEnabled() {
-    return prefetchCodebooksEnabled;
+    return workerConfig.isPrefetchCodebooksEnabled();
   }
 
-  /**
-   * When true, query waits for codebook prefetch to complete before searching (test-only).
-   */
+  /** When true, query waits for codebook prefetch to complete before searching (test-only). */
   public boolean isPrefetchCodebooksSync() {
-    return prefetchCodebooksSync;
+    return workerConfig.isPrefetchCodebooksSync();
   }
 
-  /**
-   * When true, a vacuum that leaves a segment below 50% capacity will enqueue a
-   * FindCompactionCandidates task to explore merging small sealed segments.
-   */
+  /** When true, vacuum enqueues FindCompactionCandidates for small sealed segments. */
   public boolean isAutoFindCompactionCandidates() {
-    return autoFindCompactionCandidates;
+    return workerConfig.isAutoFindCompactionCandidates();
   }
 
   /** Minimum number of segments required to trigger compaction (default 2). */
   public int getCompactionMinSegments() {
-    return compactionMinSegments;
+    return workerConfig.getCompactionMinSegments();
   }
 
   /** Maximum number of segments to merge at once (default 8). */
   public int getCompactionMaxSegments() {
-    return compactionMaxSegments;
+    return workerConfig.getCompactionMaxSegments();
   }
 
   /** Minimum average deleted ratio across candidates to proceed with compaction (default 0.1). */
   public double getCompactionMinFragmentation() {
-    return compactionMinFragmentation;
+    return workerConfig.getCompactionMinFragmentation();
   }
 
   /** Weight for age score in composite compaction ranking (default 0.3). */
   public double getCompactionAgeBiasWeight() {
-    return compactionAgeBiasWeight;
+    return workerConfig.getCompactionAgeBiasWeight();
   }
 
   /** Weight for size score (smaller = higher) in composite compaction ranking (default 0.5). */
   public double getCompactionSizeBiasWeight() {
-    return compactionSizeBiasWeight;
+    return workerConfig.getCompactionSizeBiasWeight();
   }
 
   /** Weight for fragmentation score in composite compaction ranking (default 0.2). */
   public double getCompactionFragBiasWeight() {
-    return compactionFragBiasWeight;
+    return workerConfig.getCompactionFragBiasWeight();
   }
 
-  /**
-   * Upper bound for FDB transaction size (bytes) used by segment build batching.
-   */
+  /** Upper bound for FDB transaction size (bytes) used by segment build batching. */
   public long getBuildTxnLimitBytes() {
-    return buildTxnLimitBytes;
+    return workerConfig.getBuildTxnLimitBytes();
   }
 
-  /**
-   * Ratio of limit where we split (e.g., 0.9 => leave 10% headroom).
-   */
+  /** Ratio of limit where we split (e.g., 0.9 => leave 10% headroom). */
   public double getBuildTxnSoftLimitRatio() {
-    return buildTxnSoftLimitRatio;
+    return workerConfig.getBuildTxnSoftLimitRatio();
   }
 
-  /**
-   * Writes between approximate-size checks during build batching.
-   */
+  /** Writes between approximate-size checks during build batching. */
   public int getBuildSizeCheckEvery() {
-    return buildSizeCheckEvery;
+    return workerConfig.getBuildSizeCheckEvery();
   }
 
   /**
@@ -451,10 +418,20 @@ public final class VectorIndexConfig {
     private double buildTxnSoftLimitRatio = 0.9; // leave 10% headroom
     private int buildSizeCheckEvery = 32;
     private GlobalTaskQueueConfig globalTaskQueueConfig;
+    private WorkerConfig workerConfig; // nullable; when set, overrides individual operational fields
 
     private Builder(Database database, DirectorySubspace indexDir) {
       this.database = database;
       this.indexDir = indexDir;
+    }
+
+    /**
+     * Sets a pre-built {@link WorkerConfig} for all operational settings.
+     * When set, individual operational setters on this builder are ignored.
+     */
+    public Builder workerConfig(WorkerConfig workerConfig) {
+      this.workerConfig = workerConfig;
+      return this;
     }
 
     /**

--- a/src/main/java/io/github/panghy/vectorsearch/config/VectorIndexConfig.java
+++ b/src/main/java/io/github/panghy/vectorsearch/config/VectorIndexConfig.java
@@ -67,6 +67,9 @@ public final class VectorIndexConfig {
   private final double buildTxnSoftLimitRatio;
   private final int buildSizeCheckEvery;
 
+  // Optional global task queue config
+  private final GlobalTaskQueueConfig globalTaskQueueConfig;
+
   private VectorIndexConfig(Builder b) {
     this.database = Objects.requireNonNull(b.database, "database must not be null");
     this.indexDir = Objects.requireNonNull(b.indexDir, "indexDir must not be null");
@@ -147,6 +150,8 @@ public final class VectorIndexConfig {
     this.buildTxnLimitBytes = b.buildTxnLimitBytes;
     this.buildTxnSoftLimitRatio = b.buildTxnSoftLimitRatio;
     this.buildSizeCheckEvery = b.buildSizeCheckEvery;
+
+    this.globalTaskQueueConfig = b.globalTaskQueueConfig; // nullable
   }
 
   private static Duration requirePositive(Duration d, String name) {
@@ -384,6 +389,21 @@ public final class VectorIndexConfig {
   }
 
   /**
+   * Returns the optional global task queue configuration, or {@code null} if not set.
+   */
+  public GlobalTaskQueueConfig getGlobalTaskQueueConfig() {
+    return globalTaskQueueConfig;
+  }
+
+  /**
+   * Returns {@code true} if a global task queue configuration has been set,
+   * indicating that local queues/workers should be skipped.
+   */
+  public boolean isGlobalTaskQueueEnabled() {
+    return globalTaskQueueConfig != null;
+  }
+
+  /**
    * Creates a new builder for {@link VectorIndexConfig}.
    */
   public static Builder builder(Database database, DirectorySubspace indexDir) {
@@ -430,6 +450,7 @@ public final class VectorIndexConfig {
     private long buildTxnLimitBytes = 10L * 1024 * 1024; // 10 MB
     private double buildTxnSoftLimitRatio = 0.9; // leave 10% headroom
     private int buildSizeCheckEvery = 32;
+    private GlobalTaskQueueConfig globalTaskQueueConfig;
 
     private Builder(Database database, DirectorySubspace indexDir) {
       this.database = database;
@@ -685,6 +706,18 @@ public final class VectorIndexConfig {
      */
     public Builder buildSizeCheckEvery(int n) {
       this.buildSizeCheckEvery = n;
+      return this;
+    }
+
+    /**
+     * Sets the optional global task queue configuration. When set, the index will enqueue
+     * tasks into the shared global queues and skip creating local queues/workers.
+     *
+     * @param config the global task queue config (may be {@code null} to disable)
+     * @return this builder
+     */
+    public Builder globalTaskQueueConfig(GlobalTaskQueueConfig config) {
+      this.globalTaskQueueConfig = config;
       return this;
     }
 

--- a/src/main/java/io/github/panghy/vectorsearch/config/WorkerConfig.java
+++ b/src/main/java/io/github/panghy/vectorsearch/config/WorkerConfig.java
@@ -109,6 +109,16 @@ public final class WorkerConfig {
     this.instantSource = b.instantSource;
     this.metricAttributes = Map.copyOf(b.metricAttributes);
 
+    // Validate data-format fallback defaults (same constraints as VectorIndexConfig data params)
+    if (b.defaultMaxSegmentSize <= 0) throw new IllegalArgumentException("defaultMaxSegmentSize must be positive");
+    if (b.defaultPqM <= 0) throw new IllegalArgumentException("defaultPqM must be positive");
+    if (b.defaultPqK <= 1) throw new IllegalArgumentException("defaultPqK must be > 1");
+    if (b.defaultGraphDegree <= 0) throw new IllegalArgumentException("defaultGraphDegree must be positive");
+    if (b.defaultOversample <= 0) throw new IllegalArgumentException("defaultOversample must be positive");
+    if (b.defaultGraphBuildBreadth < b.defaultGraphDegree)
+      throw new IllegalArgumentException("defaultGraphBuildBreadth must be >= defaultGraphDegree");
+    if (b.defaultGraphAlpha < 0.0) throw new IllegalArgumentException("defaultGraphAlpha must be >= 0");
+
     this.defaultMaxSegmentSize = b.defaultMaxSegmentSize;
     this.defaultPqM = b.defaultPqM;
     this.defaultPqK = b.defaultPqK;

--- a/src/main/java/io/github/panghy/vectorsearch/config/WorkerConfig.java
+++ b/src/main/java/io/github/panghy/vectorsearch/config/WorkerConfig.java
@@ -55,14 +55,45 @@ public final class WorkerConfig {
   private final double defaultGraphAlpha;
 
   private WorkerConfig(Builder b) {
+    // Validate operational invariants (same constraints as VectorIndexConfig)
+    if (b.estimatedWorkerCount <= 0) throw new IllegalArgumentException("estimatedWorkerCount must be positive");
+    if (b.maxConcurrentCompactions < 0) throw new IllegalArgumentException("maxConcurrentCompactions must be >= 0");
+    Objects.requireNonNull(b.defaultTtl, "defaultTtl must not be null");
+    if (b.defaultTtl.isZero() || b.defaultTtl.isNegative())
+      throw new IllegalArgumentException("defaultTtl must be positive");
+    Objects.requireNonNull(b.defaultThrottle, "defaultThrottle must not be null");
+    if (b.defaultThrottle.isNegative()) throw new IllegalArgumentException("defaultThrottle must not be negative");
+    Objects.requireNonNull(b.vacuumCooldown, "vacuumCooldown must not be null");
+    if (b.vacuumCooldown.isNegative()) throw new IllegalArgumentException("vacuumCooldown must be >= 0");
+    if (!(b.vacuumMinDeletedRatio >= 0.0 && b.vacuumMinDeletedRatio <= 1.0))
+      throw new IllegalArgumentException("vacuumMinDeletedRatio must be in [0,1]");
+    Objects.requireNonNull(b.instantSource, "instantSource must not be null");
+    if (b.codebookBatchLoadSize <= 0) throw new IllegalArgumentException("codebookBatchLoadSize must be positive");
+    if (b.adjacencyBatchLoadSize <= 0)
+      throw new IllegalArgumentException("adjacencyBatchLoadSize must be positive");
+    if (b.compactionMinSegments < 2) throw new IllegalArgumentException("compactionMinSegments must be >= 2");
+    if (b.compactionMaxSegments < b.compactionMinSegments)
+      throw new IllegalArgumentException("compactionMaxSegments must be >= compactionMinSegments");
+    if (!(b.compactionMinFragmentation >= 0.0 && b.compactionMinFragmentation <= 1.0))
+      throw new IllegalArgumentException("compactionMinFragmentation must be in [0,1]");
+    if (b.compactionAgeBiasWeight < 0.0) throw new IllegalArgumentException("compactionAgeBiasWeight must be >= 0");
+    if (b.compactionSizeBiasWeight < 0.0)
+      throw new IllegalArgumentException("compactionSizeBiasWeight must be >= 0");
+    if (b.compactionFragBiasWeight < 0.0)
+      throw new IllegalArgumentException("compactionFragBiasWeight must be >= 0");
+    if (b.buildTxnLimitBytes <= 0) throw new IllegalArgumentException("buildTxnLimitBytes must be positive");
+    if (!(b.buildTxnSoftLimitRatio > 0.0 && b.buildTxnSoftLimitRatio < 1.0))
+      throw new IllegalArgumentException("buildTxnSoftLimitRatio must be in (0,1)");
+    if (b.buildSizeCheckEvery <= 0) throw new IllegalArgumentException("buildSizeCheckEvery must be positive");
+
     this.estimatedWorkerCount = b.estimatedWorkerCount;
-    this.defaultTtl = Objects.requireNonNull(b.defaultTtl, "defaultTtl");
-    this.defaultThrottle = Objects.requireNonNull(b.defaultThrottle, "defaultThrottle");
+    this.defaultTtl = b.defaultTtl;
+    this.defaultThrottle = b.defaultThrottle;
     this.maxConcurrentCompactions = b.maxConcurrentCompactions;
     this.buildTxnLimitBytes = b.buildTxnLimitBytes;
     this.buildTxnSoftLimitRatio = b.buildTxnSoftLimitRatio;
     this.buildSizeCheckEvery = b.buildSizeCheckEvery;
-    this.vacuumCooldown = Objects.requireNonNull(b.vacuumCooldown, "vacuumCooldown");
+    this.vacuumCooldown = b.vacuumCooldown;
     this.vacuumMinDeletedRatio = b.vacuumMinDeletedRatio;
     this.autoFindCompactionCandidates = b.autoFindCompactionCandidates;
     this.compactionMinSegments = b.compactionMinSegments;
@@ -75,7 +106,7 @@ public final class WorkerConfig {
     this.adjacencyBatchLoadSize = b.adjacencyBatchLoadSize;
     this.prefetchCodebooksEnabled = b.prefetchCodebooksEnabled;
     this.prefetchCodebooksSync = b.prefetchCodebooksSync;
-    this.instantSource = Objects.requireNonNull(b.instantSource, "instantSource");
+    this.instantSource = b.instantSource;
     this.metricAttributes = Map.copyOf(b.metricAttributes);
 
     this.defaultMaxSegmentSize = b.defaultMaxSegmentSize;

--- a/src/main/java/io/github/panghy/vectorsearch/config/WorkerConfig.java
+++ b/src/main/java/io/github/panghy/vectorsearch/config/WorkerConfig.java
@@ -1,0 +1,414 @@
+package io.github.panghy.vectorsearch.config;
+
+import java.time.Duration;
+import java.time.InstantSource;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Immutable configuration for global worker operational settings.
+ *
+ * <p>Holds all operational knobs that control how background workers behave (TTL, throttle,
+ * compaction planner, vacuum, build batching, caches, etc.) plus data-format fallback defaults
+ * used by {@code GlobalWorkerRunner} when {@code IndexMeta} has zero/default values.</p>
+ *
+ * <p>This class eliminates the need to construct a full {@link VectorIndexConfig} (with its
+ * required {@code database} and {@code indexDir}) just to supply operational settings to
+ * {@code GlobalWorkerRunner}.</p>
+ *
+ * @see VectorIndexConfig
+ */
+public final class WorkerConfig {
+
+  // Operational settings
+  private final int estimatedWorkerCount;
+  private final Duration defaultTtl;
+  private final Duration defaultThrottle;
+  private final int maxConcurrentCompactions;
+  private final long buildTxnLimitBytes;
+  private final double buildTxnSoftLimitRatio;
+  private final int buildSizeCheckEvery;
+  private final Duration vacuumCooldown;
+  private final double vacuumMinDeletedRatio;
+  private final boolean autoFindCompactionCandidates;
+  private final int compactionMinSegments;
+  private final int compactionMaxSegments;
+  private final double compactionMinFragmentation;
+  private final double compactionAgeBiasWeight;
+  private final double compactionSizeBiasWeight;
+  private final double compactionFragBiasWeight;
+  private final int codebookBatchLoadSize;
+  private final int adjacencyBatchLoadSize;
+  private final boolean prefetchCodebooksEnabled;
+  private final boolean prefetchCodebooksSync;
+  private final InstantSource instantSource;
+  private final Map<String, String> metricAttributes;
+
+  // Data-format fallback defaults
+  private final int defaultMaxSegmentSize;
+  private final int defaultPqM;
+  private final int defaultPqK;
+  private final int defaultGraphDegree;
+  private final int defaultOversample;
+  private final int defaultGraphBuildBreadth;
+  private final double defaultGraphAlpha;
+
+  private WorkerConfig(Builder b) {
+    this.estimatedWorkerCount = b.estimatedWorkerCount;
+    this.defaultTtl = Objects.requireNonNull(b.defaultTtl, "defaultTtl");
+    this.defaultThrottle = Objects.requireNonNull(b.defaultThrottle, "defaultThrottle");
+    this.maxConcurrentCompactions = b.maxConcurrentCompactions;
+    this.buildTxnLimitBytes = b.buildTxnLimitBytes;
+    this.buildTxnSoftLimitRatio = b.buildTxnSoftLimitRatio;
+    this.buildSizeCheckEvery = b.buildSizeCheckEvery;
+    this.vacuumCooldown = Objects.requireNonNull(b.vacuumCooldown, "vacuumCooldown");
+    this.vacuumMinDeletedRatio = b.vacuumMinDeletedRatio;
+    this.autoFindCompactionCandidates = b.autoFindCompactionCandidates;
+    this.compactionMinSegments = b.compactionMinSegments;
+    this.compactionMaxSegments = b.compactionMaxSegments;
+    this.compactionMinFragmentation = b.compactionMinFragmentation;
+    this.compactionAgeBiasWeight = b.compactionAgeBiasWeight;
+    this.compactionSizeBiasWeight = b.compactionSizeBiasWeight;
+    this.compactionFragBiasWeight = b.compactionFragBiasWeight;
+    this.codebookBatchLoadSize = b.codebookBatchLoadSize;
+    this.adjacencyBatchLoadSize = b.adjacencyBatchLoadSize;
+    this.prefetchCodebooksEnabled = b.prefetchCodebooksEnabled;
+    this.prefetchCodebooksSync = b.prefetchCodebooksSync;
+    this.instantSource = Objects.requireNonNull(b.instantSource, "instantSource");
+    this.metricAttributes = Map.copyOf(b.metricAttributes);
+
+    this.defaultMaxSegmentSize = b.defaultMaxSegmentSize;
+    this.defaultPqM = b.defaultPqM;
+    this.defaultPqK = b.defaultPqK;
+    this.defaultGraphDegree = b.defaultGraphDegree;
+    this.defaultOversample = b.defaultOversample;
+    this.defaultGraphBuildBreadth = b.defaultGraphBuildBreadth;
+    this.defaultGraphAlpha = b.defaultGraphAlpha;
+  }
+
+  /** Creates a new builder with sensible defaults matching {@link VectorIndexConfig.Builder}. */
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  // ---- Operational getters ----
+
+  public int getEstimatedWorkerCount() {
+    return estimatedWorkerCount;
+  }
+
+  public Duration getDefaultTtl() {
+    return defaultTtl;
+  }
+
+  public Duration getDefaultThrottle() {
+    return defaultThrottle;
+  }
+
+  public int getMaxConcurrentCompactions() {
+    return maxConcurrentCompactions;
+  }
+
+  public long getBuildTxnLimitBytes() {
+    return buildTxnLimitBytes;
+  }
+
+  public double getBuildTxnSoftLimitRatio() {
+    return buildTxnSoftLimitRatio;
+  }
+
+  public int getBuildSizeCheckEvery() {
+    return buildSizeCheckEvery;
+  }
+
+  public Duration getVacuumCooldown() {
+    return vacuumCooldown;
+  }
+
+  public double getVacuumMinDeletedRatio() {
+    return vacuumMinDeletedRatio;
+  }
+
+  public boolean isAutoFindCompactionCandidates() {
+    return autoFindCompactionCandidates;
+  }
+
+  public int getCompactionMinSegments() {
+    return compactionMinSegments;
+  }
+
+  public int getCompactionMaxSegments() {
+    return compactionMaxSegments;
+  }
+
+  public double getCompactionMinFragmentation() {
+    return compactionMinFragmentation;
+  }
+
+  public double getCompactionAgeBiasWeight() {
+    return compactionAgeBiasWeight;
+  }
+
+  public double getCompactionSizeBiasWeight() {
+    return compactionSizeBiasWeight;
+  }
+
+  public double getCompactionFragBiasWeight() {
+    return compactionFragBiasWeight;
+  }
+
+  public int getCodebookBatchLoadSize() {
+    return codebookBatchLoadSize;
+  }
+
+  public int getAdjacencyBatchLoadSize() {
+    return adjacencyBatchLoadSize;
+  }
+
+  public boolean isPrefetchCodebooksEnabled() {
+    return prefetchCodebooksEnabled;
+  }
+
+  public boolean isPrefetchCodebooksSync() {
+    return prefetchCodebooksSync;
+  }
+
+  public InstantSource getInstantSource() {
+    return instantSource;
+  }
+
+  public Map<String, String> getMetricAttributes() {
+    return metricAttributes;
+  }
+
+  // ---- Data-format fallback getters ----
+
+  public int getDefaultMaxSegmentSize() {
+    return defaultMaxSegmentSize;
+  }
+
+  public int getDefaultPqM() {
+    return defaultPqM;
+  }
+
+  public int getDefaultPqK() {
+    return defaultPqK;
+  }
+
+  public int getDefaultGraphDegree() {
+    return defaultGraphDegree;
+  }
+
+  public int getDefaultOversample() {
+    return defaultOversample;
+  }
+
+  public int getDefaultGraphBuildBreadth() {
+    return defaultGraphBuildBreadth;
+  }
+
+  public double getDefaultGraphAlpha() {
+    return defaultGraphAlpha;
+  }
+
+  /** Builder for {@link WorkerConfig}. */
+  public static final class Builder {
+    // Operational — defaults match VectorIndexConfig.Builder
+    private int estimatedWorkerCount = 1;
+    private Duration defaultTtl = Duration.ofMinutes(5);
+    private Duration defaultThrottle = Duration.ofSeconds(1);
+    private int maxConcurrentCompactions = 1;
+    private long buildTxnLimitBytes = 10L * 1024 * 1024;
+    private double buildTxnSoftLimitRatio = 0.9;
+    private int buildSizeCheckEvery = 32;
+    private Duration vacuumCooldown = Duration.ZERO;
+    private double vacuumMinDeletedRatio = 0.25;
+    private boolean autoFindCompactionCandidates = true;
+    private int compactionMinSegments = 2;
+    private int compactionMaxSegments = 8;
+    private double compactionMinFragmentation = 0.1;
+    private double compactionAgeBiasWeight = 0.3;
+    private double compactionSizeBiasWeight = 0.5;
+    private double compactionFragBiasWeight = 0.2;
+    private int codebookBatchLoadSize = 10_000;
+    private int adjacencyBatchLoadSize = 10_000;
+    private boolean prefetchCodebooksEnabled = true;
+    private boolean prefetchCodebooksSync = false;
+    private InstantSource instantSource = InstantSource.system();
+    private final Map<String, String> metricAttributes = new HashMap<>();
+
+    // Data-format fallback defaults — match VectorIndexConfig.Builder
+    private int defaultMaxSegmentSize = 100_000;
+    private int defaultPqM = 16;
+    private int defaultPqK = 256;
+    private int defaultGraphDegree = 64;
+    private int defaultOversample = 2;
+    private int defaultGraphBuildBreadth = 256;
+    private double defaultGraphAlpha = 1.2;
+
+    private Builder() {}
+
+    // ---- Operational setters ----
+
+    public Builder estimatedWorkerCount(int v) {
+      this.estimatedWorkerCount = v;
+      return this;
+    }
+
+    public Builder defaultTtl(Duration v) {
+      this.defaultTtl = v;
+      return this;
+    }
+
+    public Builder defaultThrottle(Duration v) {
+      this.defaultThrottle = v;
+      return this;
+    }
+
+    public Builder maxConcurrentCompactions(int v) {
+      this.maxConcurrentCompactions = v;
+      return this;
+    }
+
+    public Builder buildTxnLimitBytes(long v) {
+      this.buildTxnLimitBytes = v;
+      return this;
+    }
+
+    public Builder buildTxnSoftLimitRatio(double v) {
+      this.buildTxnSoftLimitRatio = v;
+      return this;
+    }
+
+    public Builder buildSizeCheckEvery(int v) {
+      this.buildSizeCheckEvery = v;
+      return this;
+    }
+
+    public Builder vacuumCooldown(Duration v) {
+      this.vacuumCooldown = v;
+      return this;
+    }
+
+    public Builder vacuumMinDeletedRatio(double v) {
+      this.vacuumMinDeletedRatio = v;
+      return this;
+    }
+
+    public Builder autoFindCompactionCandidates(boolean v) {
+      this.autoFindCompactionCandidates = v;
+      return this;
+    }
+
+    public Builder compactionMinSegments(int v) {
+      this.compactionMinSegments = v;
+      return this;
+    }
+
+    public Builder compactionMaxSegments(int v) {
+      this.compactionMaxSegments = v;
+      return this;
+    }
+
+    public Builder compactionMinFragmentation(double v) {
+      this.compactionMinFragmentation = v;
+      return this;
+    }
+
+    public Builder compactionAgeBiasWeight(double v) {
+      this.compactionAgeBiasWeight = v;
+      return this;
+    }
+
+    public Builder compactionSizeBiasWeight(double v) {
+      this.compactionSizeBiasWeight = v;
+      return this;
+    }
+
+    public Builder compactionFragBiasWeight(double v) {
+      this.compactionFragBiasWeight = v;
+      return this;
+    }
+
+    public Builder codebookBatchLoadSize(int v) {
+      this.codebookBatchLoadSize = v;
+      return this;
+    }
+
+    public Builder adjacencyBatchLoadSize(int v) {
+      this.adjacencyBatchLoadSize = v;
+      return this;
+    }
+
+    public Builder prefetchCodebooksEnabled(boolean v) {
+      this.prefetchCodebooksEnabled = v;
+      return this;
+    }
+
+    public Builder prefetchCodebooksSync(boolean v) {
+      this.prefetchCodebooksSync = v;
+      return this;
+    }
+
+    public Builder instantSource(InstantSource v) {
+      this.instantSource = v;
+      return this;
+    }
+
+    /** Adds a single metric attribute. */
+    public Builder metricAttribute(String key, String value) {
+      this.metricAttributes.put(key, value);
+      return this;
+    }
+
+    /** Sets metric attributes in bulk (copied). */
+    public Builder metricAttributes(Map<String, String> attrs) {
+      this.metricAttributes.clear();
+      if (attrs != null) this.metricAttributes.putAll(attrs);
+      return this;
+    }
+
+    // ---- Data-format fallback setters ----
+
+    public Builder defaultMaxSegmentSize(int v) {
+      this.defaultMaxSegmentSize = v;
+      return this;
+    }
+
+    public Builder defaultPqM(int v) {
+      this.defaultPqM = v;
+      return this;
+    }
+
+    public Builder defaultPqK(int v) {
+      this.defaultPqK = v;
+      return this;
+    }
+
+    public Builder defaultGraphDegree(int v) {
+      this.defaultGraphDegree = v;
+      return this;
+    }
+
+    public Builder defaultOversample(int v) {
+      this.defaultOversample = v;
+      return this;
+    }
+
+    public Builder defaultGraphBuildBreadth(int v) {
+      this.defaultGraphBuildBreadth = v;
+      return this;
+    }
+
+    public Builder defaultGraphAlpha(double v) {
+      this.defaultGraphAlpha = v;
+      return this;
+    }
+
+    /** Builds the immutable {@link WorkerConfig}. */
+    public WorkerConfig build() {
+      return new WorkerConfig(this);
+    }
+  }
+}

--- a/src/main/java/io/github/panghy/vectorsearch/fdb/FdbVectorIndex.java
+++ b/src/main/java/io/github/panghy/vectorsearch/fdb/FdbVectorIndex.java
@@ -19,11 +19,14 @@ import io.github.panghy.vectorsearch.api.SearchParams;
 import io.github.panghy.vectorsearch.api.SearchResult;
 import io.github.panghy.vectorsearch.api.VectorIndex;
 import io.github.panghy.vectorsearch.cache.SegmentCaches;
+import io.github.panghy.vectorsearch.config.GlobalTaskQueueConfig;
 import io.github.panghy.vectorsearch.config.VectorIndexConfig;
 import io.github.panghy.vectorsearch.proto.BuildTask;
 import io.github.panghy.vectorsearch.proto.MaintenanceTask;
 import io.github.panghy.vectorsearch.proto.SegmentMeta;
 import io.github.panghy.vectorsearch.proto.VectorRecord;
+import io.github.panghy.vectorsearch.tasks.GlobalBuildQueueAdapter;
+import io.github.panghy.vectorsearch.tasks.GlobalMaintenanceQueueAdapter;
 import io.github.panghy.vectorsearch.tasks.MaintenanceWorkerPool;
 import io.github.panghy.vectorsearch.tasks.ProtoSerializers;
 import io.github.panghy.vectorsearch.tasks.ProtoSerializers.BuildTaskSerializer;
@@ -116,6 +119,9 @@ public class FdbVectorIndex implements VectorIndex, AutoCloseable {
   // Creates or opens the index asynchronously and returns a ready VectorIndex.
   public static CompletableFuture<FdbVectorIndex> createOrOpen(VectorIndexConfig config) {
     Database db = config.getDatabase();
+    if (config.isGlobalTaskQueueEnabled()) {
+      return createOrOpenWithGlobalQueues(config, db);
+    }
     return FdbDirectories.openIndex(config.getIndexDir(), db)
         .thenCompose(dirs -> createBuildQueue(config, dirs).thenCompose(buildQ -> {
           FdbVectorStore store = new FdbVectorStore(config, dirs, buildQ);
@@ -141,6 +147,32 @@ public class FdbVectorIndex implements VectorIndex, AutoCloseable {
                 return ix;
               });
         }));
+  }
+
+  /**
+   * Creates or opens the index using global (cross-index) task queues. No local queues or
+   * workers are created; enqueue calls are routed through adapter queues that prepend the
+   * index directory path and delegate to the shared global queues.
+   */
+  private static CompletableFuture<FdbVectorIndex> createOrOpenWithGlobalQueues(
+      VectorIndexConfig config, Database db) {
+    GlobalTaskQueueConfig globalCfg = config.getGlobalTaskQueueConfig();
+    List<String> indexPath = config.getIndexDir().getPath();
+    TaskQueue<String, BuildTask> buildAdapter = new GlobalBuildQueueAdapter(globalCfg.getBuildQueue(), indexPath);
+    TaskQueue<String, MaintenanceTask> maintAdapter =
+        new GlobalMaintenanceQueueAdapter(globalCfg.getMaintenanceQueue(), indexPath);
+    return FdbDirectories.openIndex(config.getIndexDir(), db).thenCompose(dirs -> {
+      FdbVectorStore store = new FdbVectorStore(config, dirs, buildAdapter);
+      CompletableFuture<Void> init =
+          store.createOrOpenIndex().thenCompose(v -> ensureCurrentSubspaces(config, dirs));
+      return init.thenApply(v -> {
+        FdbVectorIndex ix = new FdbVectorIndex(config, store, dirs);
+        ix.buildQueue = buildAdapter;
+        ix.maintenanceQueue = maintAdapter;
+        LOG.info("Opened index with global task queues (indexPath={}).", indexPath);
+        return ix;
+      });
+    });
   }
 
   private static CompletableFuture<Void> ensureCurrentSubspaces(

--- a/src/main/java/io/github/panghy/vectorsearch/tasks/GlobalBuildQueueAdapter.java
+++ b/src/main/java/io/github/panghy/vectorsearch/tasks/GlobalBuildQueueAdapter.java
@@ -32,6 +32,7 @@ public final class GlobalBuildQueueAdapter implements TaskQueue<String, BuildTas
 
   private final TaskQueue<String, GlobalBuildTask> globalQueue;
   private final List<String> indexPath;
+  private final String keyPrefix;
 
   /**
    * Creates a new adapter.
@@ -42,6 +43,7 @@ public final class GlobalBuildQueueAdapter implements TaskQueue<String, BuildTas
   public GlobalBuildQueueAdapter(TaskQueue<String, GlobalBuildTask> globalQueue, List<String> indexPath) {
     this.globalQueue = requireNonNull(globalQueue, "globalQueue");
     this.indexPath = List.copyOf(requireNonNull(indexPath, "indexPath"));
+    this.keyPrefix = String.join("/", this.indexPath) + ":";
   }
 
   @Override
@@ -61,7 +63,7 @@ public final class GlobalBuildQueueAdapter implements TaskQueue<String, BuildTas
         .addAllIndexPath(indexPath)
         .setTask(task)
         .build();
-    return globalQueue.enqueue(tx, key, wrapped, ttl, throttle);
+    return globalQueue.enqueue(tx, keyPrefix + key, wrapped, ttl, throttle);
   }
 
   @Override
@@ -70,7 +72,7 @@ public final class GlobalBuildQueueAdapter implements TaskQueue<String, BuildTas
         .addAllIndexPath(indexPath)
         .setTask(task)
         .build();
-    return globalQueue.enqueueIfNotExists(tx, key, wrapped);
+    return globalQueue.enqueueIfNotExists(tx, keyPrefix + key, wrapped);
   }
 
   @Override
@@ -80,7 +82,7 @@ public final class GlobalBuildQueueAdapter implements TaskQueue<String, BuildTas
         .addAllIndexPath(indexPath)
         .setTask(task)
         .build();
-    return globalQueue.enqueueIfNotExists(tx, key, wrapped, ttl, throttle, updatePayload);
+    return globalQueue.enqueueIfNotExists(tx, keyPrefix + key, wrapped, ttl, throttle, updatePayload);
   }
 
   @Override

--- a/src/main/java/io/github/panghy/vectorsearch/tasks/GlobalBuildQueueAdapter.java
+++ b/src/main/java/io/github/panghy/vectorsearch/tasks/GlobalBuildQueueAdapter.java
@@ -1,0 +1,120 @@
+package io.github.panghy.vectorsearch.tasks;
+
+import static java.util.Objects.requireNonNull;
+
+import com.apple.foundationdb.Database;
+import com.apple.foundationdb.Transaction;
+import io.github.panghy.taskqueue.TaskClaim;
+import io.github.panghy.taskqueue.TaskQueue;
+import io.github.panghy.taskqueue.TaskQueueConfig;
+import io.github.panghy.taskqueue.proto.TaskKeyMetadata;
+import io.github.panghy.vectorsearch.proto.BuildTask;
+import io.github.panghy.vectorsearch.proto.GlobalBuildTask;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+
+/**
+ * Adapter that implements {@link TaskQueue TaskQueue&lt;String, BuildTask&gt;} by wrapping each
+ * enqueued {@link BuildTask} into a {@link GlobalBuildTask} (with the index directory path) and
+ * delegating to the shared global build queue.
+ *
+ * <p>Only producer methods ({@code enqueue}, {@code enqueueIfNotExists}) and
+ * {@link #awaitQueueEmpty(Database)} are supported. Consumer and inspection methods throw
+ * {@link UnsupportedOperationException} because local workers are not started when global mode
+ * is enabled.</p>
+ *
+ * <p><b>Note:</b> {@link #awaitQueueEmpty(Database)} delegates to the global queue, so it waits
+ * for <em>all</em> global build tasks to drain — not just those belonging to this index.</p>
+ */
+public final class GlobalBuildQueueAdapter implements TaskQueue<String, BuildTask> {
+
+  private final TaskQueue<String, GlobalBuildTask> globalQueue;
+  private final List<String> indexPath;
+
+  /**
+   * Creates a new adapter.
+   *
+   * @param globalQueue the shared global build task queue
+   * @param indexPath   the directory path components identifying this index
+   */
+  public GlobalBuildQueueAdapter(TaskQueue<String, GlobalBuildTask> globalQueue, List<String> indexPath) {
+    this.globalQueue = requireNonNull(globalQueue, "globalQueue");
+    this.indexPath = List.copyOf(requireNonNull(indexPath, "indexPath"));
+  }
+
+  @Override
+  public TaskQueueConfig<String, BuildTask> getConfig() {
+    throw new UnsupportedOperationException("GlobalBuildQueueAdapter does not have a local config");
+  }
+
+  @Override
+  public <R> CompletableFuture<R> runAsync(Function<Transaction, CompletableFuture<R>> function) {
+    return globalQueue.runAsync(function);
+  }
+
+  @Override
+  public CompletableFuture<TaskKeyMetadata> enqueue(
+      Transaction tx, String key, BuildTask task, Duration ttl, Duration throttle) {
+    GlobalBuildTask wrapped = GlobalBuildTask.newBuilder()
+        .addAllIndexPath(indexPath)
+        .setTask(task)
+        .build();
+    return globalQueue.enqueue(tx, key, wrapped, ttl, throttle);
+  }
+
+  @Override
+  public CompletableFuture<TaskKeyMetadata> enqueueIfNotExists(
+      Transaction tx, String key, BuildTask task, Duration ttl, Duration throttle, boolean updatePayload) {
+    GlobalBuildTask wrapped = GlobalBuildTask.newBuilder()
+        .addAllIndexPath(indexPath)
+        .setTask(task)
+        .build();
+    return globalQueue.enqueueIfNotExists(tx, key, wrapped, ttl, throttle, updatePayload);
+  }
+
+  @Override
+  public CompletableFuture<TaskClaim<String, BuildTask>> awaitAndClaimTask(Database db) {
+    throw new UnsupportedOperationException("Local workers are not used when global task queue mode is enabled");
+  }
+
+  @Override
+  public CompletableFuture<Void> completeTask(Transaction tx, TaskClaim<String, BuildTask> claim) {
+    throw new UnsupportedOperationException("Local workers are not used when global task queue mode is enabled");
+  }
+
+  @Override
+  public CompletableFuture<Void> failTask(Transaction tx, TaskClaim<String, BuildTask> claim) {
+    throw new UnsupportedOperationException("Local workers are not used when global task queue mode is enabled");
+  }
+
+  @Override
+  public CompletableFuture<Void> extendTtl(Transaction tx, TaskClaim<String, BuildTask> claim, Duration ttl) {
+    throw new UnsupportedOperationException("Local workers are not used when global task queue mode is enabled");
+  }
+
+  @Override
+  public CompletableFuture<Boolean> isEmpty(Transaction tx) {
+    throw new UnsupportedOperationException("Local workers are not used when global task queue mode is enabled");
+  }
+
+  @Override
+  public CompletableFuture<Boolean> hasVisibleUnclaimedTasks(Transaction tx) {
+    throw new UnsupportedOperationException("Local workers are not used when global task queue mode is enabled");
+  }
+
+  @Override
+  public CompletableFuture<Boolean> hasClaimedTasks(Transaction tx) {
+    throw new UnsupportedOperationException("Local workers are not used when global task queue mode is enabled");
+  }
+
+  /**
+   * Delegates to the global queue's {@code awaitQueueEmpty}. Note: this waits for <em>all</em>
+   * global build tasks to drain, not just those belonging to this index.
+   */
+  @Override
+  public CompletableFuture<Void> awaitQueueEmpty(Database db) {
+    return globalQueue.awaitQueueEmpty(db);
+  }
+}

--- a/src/main/java/io/github/panghy/vectorsearch/tasks/GlobalBuildQueueAdapter.java
+++ b/src/main/java/io/github/panghy/vectorsearch/tasks/GlobalBuildQueueAdapter.java
@@ -65,6 +65,15 @@ public final class GlobalBuildQueueAdapter implements TaskQueue<String, BuildTas
   }
 
   @Override
+  public CompletableFuture<TaskKeyMetadata> enqueueIfNotExists(Transaction tx, String key, BuildTask task) {
+    GlobalBuildTask wrapped = GlobalBuildTask.newBuilder()
+        .addAllIndexPath(indexPath)
+        .setTask(task)
+        .build();
+    return globalQueue.enqueueIfNotExists(tx, key, wrapped);
+  }
+
+  @Override
   public CompletableFuture<TaskKeyMetadata> enqueueIfNotExists(
       Transaction tx, String key, BuildTask task, Duration ttl, Duration throttle, boolean updatePayload) {
     GlobalBuildTask wrapped = GlobalBuildTask.newBuilder()

--- a/src/main/java/io/github/panghy/vectorsearch/tasks/GlobalMaintenanceQueueAdapter.java
+++ b/src/main/java/io/github/panghy/vectorsearch/tasks/GlobalMaintenanceQueueAdapter.java
@@ -61,6 +61,15 @@ public final class GlobalMaintenanceQueueAdapter implements TaskQueue<String, Ma
   }
 
   @Override
+  public CompletableFuture<TaskKeyMetadata> enqueueIfNotExists(Transaction tx, String key, MaintenanceTask task) {
+    GlobalMaintenanceTask wrapped = GlobalMaintenanceTask.newBuilder()
+        .addAllIndexPath(indexPath)
+        .setTask(task)
+        .build();
+    return globalQueue.enqueueIfNotExists(tx, key, wrapped);
+  }
+
+  @Override
   public CompletableFuture<TaskKeyMetadata> enqueueIfNotExists(
       Transaction tx, String key, MaintenanceTask task, Duration ttl, Duration throttle, boolean updatePayload) {
     GlobalMaintenanceTask wrapped = GlobalMaintenanceTask.newBuilder()

--- a/src/main/java/io/github/panghy/vectorsearch/tasks/GlobalMaintenanceQueueAdapter.java
+++ b/src/main/java/io/github/panghy/vectorsearch/tasks/GlobalMaintenanceQueueAdapter.java
@@ -1,0 +1,112 @@
+package io.github.panghy.vectorsearch.tasks;
+
+import static java.util.Objects.requireNonNull;
+
+import com.apple.foundationdb.Database;
+import com.apple.foundationdb.Transaction;
+import io.github.panghy.taskqueue.TaskClaim;
+import io.github.panghy.taskqueue.TaskQueue;
+import io.github.panghy.taskqueue.TaskQueueConfig;
+import io.github.panghy.taskqueue.proto.TaskKeyMetadata;
+import io.github.panghy.vectorsearch.proto.GlobalMaintenanceTask;
+import io.github.panghy.vectorsearch.proto.MaintenanceTask;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+
+/**
+ * Adapter that implements {@link TaskQueue TaskQueue&lt;String, MaintenanceTask&gt;} by wrapping
+ * each enqueued {@link MaintenanceTask} into a {@link GlobalMaintenanceTask} (with the index
+ * directory path) and delegating to the shared global maintenance queue.
+ *
+ * <p>Only producer methods ({@code enqueue}, {@code enqueueIfNotExists}) are supported. Consumer
+ * and inspection methods throw {@link UnsupportedOperationException} because local workers are
+ * not started when global mode is enabled.</p>
+ */
+public final class GlobalMaintenanceQueueAdapter implements TaskQueue<String, MaintenanceTask> {
+
+  private final TaskQueue<String, GlobalMaintenanceTask> globalQueue;
+  private final List<String> indexPath;
+
+  /**
+   * Creates a new adapter.
+   *
+   * @param globalQueue the shared global maintenance task queue
+   * @param indexPath   the directory path components identifying this index
+   */
+  public GlobalMaintenanceQueueAdapter(TaskQueue<String, GlobalMaintenanceTask> globalQueue, List<String> indexPath) {
+    this.globalQueue = requireNonNull(globalQueue, "globalQueue");
+    this.indexPath = List.copyOf(requireNonNull(indexPath, "indexPath"));
+  }
+
+  @Override
+  public TaskQueueConfig<String, MaintenanceTask> getConfig() {
+    throw new UnsupportedOperationException("GlobalMaintenanceQueueAdapter does not have a local config");
+  }
+
+  @Override
+  public <R> CompletableFuture<R> runAsync(Function<Transaction, CompletableFuture<R>> function) {
+    return globalQueue.runAsync(function);
+  }
+
+  @Override
+  public CompletableFuture<TaskKeyMetadata> enqueue(
+      Transaction tx, String key, MaintenanceTask task, Duration ttl, Duration throttle) {
+    GlobalMaintenanceTask wrapped = GlobalMaintenanceTask.newBuilder()
+        .addAllIndexPath(indexPath)
+        .setTask(task)
+        .build();
+    return globalQueue.enqueue(tx, key, wrapped, ttl, throttle);
+  }
+
+  @Override
+  public CompletableFuture<TaskKeyMetadata> enqueueIfNotExists(
+      Transaction tx, String key, MaintenanceTask task, Duration ttl, Duration throttle, boolean updatePayload) {
+    GlobalMaintenanceTask wrapped = GlobalMaintenanceTask.newBuilder()
+        .addAllIndexPath(indexPath)
+        .setTask(task)
+        .build();
+    return globalQueue.enqueueIfNotExists(tx, key, wrapped, ttl, throttle, updatePayload);
+  }
+
+  @Override
+  public CompletableFuture<TaskClaim<String, MaintenanceTask>> awaitAndClaimTask(Database db) {
+    throw new UnsupportedOperationException("Local workers are not used when global task queue mode is enabled");
+  }
+
+  @Override
+  public CompletableFuture<Void> completeTask(Transaction tx, TaskClaim<String, MaintenanceTask> claim) {
+    throw new UnsupportedOperationException("Local workers are not used when global task queue mode is enabled");
+  }
+
+  @Override
+  public CompletableFuture<Void> failTask(Transaction tx, TaskClaim<String, MaintenanceTask> claim) {
+    throw new UnsupportedOperationException("Local workers are not used when global task queue mode is enabled");
+  }
+
+  @Override
+  public CompletableFuture<Void> extendTtl(Transaction tx, TaskClaim<String, MaintenanceTask> claim, Duration ttl) {
+    throw new UnsupportedOperationException("Local workers are not used when global task queue mode is enabled");
+  }
+
+  @Override
+  public CompletableFuture<Boolean> isEmpty(Transaction tx) {
+    throw new UnsupportedOperationException("Local workers are not used when global task queue mode is enabled");
+  }
+
+  @Override
+  public CompletableFuture<Boolean> hasVisibleUnclaimedTasks(Transaction tx) {
+    throw new UnsupportedOperationException("Local workers are not used when global task queue mode is enabled");
+  }
+
+  @Override
+  public CompletableFuture<Boolean> hasClaimedTasks(Transaction tx) {
+    throw new UnsupportedOperationException("Local workers are not used when global task queue mode is enabled");
+  }
+
+  @Override
+  public CompletableFuture<Void> awaitQueueEmpty(Database db) {
+    throw new UnsupportedOperationException("Local workers are not used when global task queue mode is enabled");
+  }
+}

--- a/src/main/java/io/github/panghy/vectorsearch/tasks/GlobalMaintenanceQueueAdapter.java
+++ b/src/main/java/io/github/panghy/vectorsearch/tasks/GlobalMaintenanceQueueAdapter.java
@@ -28,6 +28,7 @@ public final class GlobalMaintenanceQueueAdapter implements TaskQueue<String, Ma
 
   private final TaskQueue<String, GlobalMaintenanceTask> globalQueue;
   private final List<String> indexPath;
+  private final String keyPrefix;
 
   /**
    * Creates a new adapter.
@@ -38,6 +39,7 @@ public final class GlobalMaintenanceQueueAdapter implements TaskQueue<String, Ma
   public GlobalMaintenanceQueueAdapter(TaskQueue<String, GlobalMaintenanceTask> globalQueue, List<String> indexPath) {
     this.globalQueue = requireNonNull(globalQueue, "globalQueue");
     this.indexPath = List.copyOf(requireNonNull(indexPath, "indexPath"));
+    this.keyPrefix = String.join("/", this.indexPath) + ":";
   }
 
   @Override
@@ -57,7 +59,7 @@ public final class GlobalMaintenanceQueueAdapter implements TaskQueue<String, Ma
         .addAllIndexPath(indexPath)
         .setTask(task)
         .build();
-    return globalQueue.enqueue(tx, key, wrapped, ttl, throttle);
+    return globalQueue.enqueue(tx, keyPrefix + key, wrapped, ttl, throttle);
   }
 
   @Override
@@ -66,7 +68,7 @@ public final class GlobalMaintenanceQueueAdapter implements TaskQueue<String, Ma
         .addAllIndexPath(indexPath)
         .setTask(task)
         .build();
-    return globalQueue.enqueueIfNotExists(tx, key, wrapped);
+    return globalQueue.enqueueIfNotExists(tx, keyPrefix + key, wrapped);
   }
 
   @Override
@@ -76,7 +78,7 @@ public final class GlobalMaintenanceQueueAdapter implements TaskQueue<String, Ma
         .addAllIndexPath(indexPath)
         .setTask(task)
         .build();
-    return globalQueue.enqueueIfNotExists(tx, key, wrapped, ttl, throttle, updatePayload);
+    return globalQueue.enqueueIfNotExists(tx, keyPrefix + key, wrapped, ttl, throttle, updatePayload);
   }
 
   @Override

--- a/src/main/java/io/github/panghy/vectorsearch/tasks/GlobalWorkerRunner.java
+++ b/src/main/java/io/github/panghy/vectorsearch/tasks/GlobalWorkerRunner.java
@@ -161,12 +161,22 @@ public final class GlobalWorkerRunner implements AutoCloseable {
   CompletableFuture<Boolean> runOnceBuild() {
     return buildQueue.awaitAndClaimTask().thenCompose(claim -> {
       GlobalBuildTask gbt = claim.task();
+      // Validate wrapper: must have a task payload
+      if (!gbt.hasTask()) {
+        LOG.debug("Build task missing inner BuildTask payload; failing claim");
+        return claim.fail().thenApply(v -> true);
+      }
       BuildTask bt = gbt.getTask();
       // Sentinel: seg_id < 0 means shutdown signal
       if (bt.getSegId() < 0) {
         return claim.complete().thenApply(v -> true);
       }
+      // Validate index_path: must be non-empty with no blank elements
       List<String> indexPath = gbt.getIndexPathList();
+      if (!isValidIndexPath(indexPath)) {
+        LOG.debug("Build task has invalid index_path={}; failing claim", indexPath);
+        return claim.fail().thenApply(v -> true);
+      }
       return resolveIndexDirs(indexPath)
           .thenCompose(dirs -> buildConfigForIndex(dirs, indexPath).thenCompose(cfg -> {
             SegmentBuildService svc = new SegmentBuildService(cfg, dirs);
@@ -186,12 +196,22 @@ public final class GlobalWorkerRunner implements AutoCloseable {
   CompletableFuture<Boolean> runOnceMaint() {
     return maintenanceQueue.awaitAndClaimTask().thenCompose(claim -> {
       GlobalMaintenanceTask gmt = claim.task();
+      // Validate wrapper: must have a task payload
+      if (!gmt.hasTask()) {
+        LOG.debug("Maintenance task missing inner MaintenanceTask payload; failing claim");
+        return claim.fail().thenApply(v -> true);
+      }
       MaintenanceTask mt = gmt.getTask();
       // Sentinel: vacuum with seg_id < 0 means shutdown signal
       if (mt.hasVacuum() && mt.getVacuum().getSegId() < 0) {
         return claim.complete().thenApply(v -> true);
       }
+      // Validate index_path: must be non-empty with no blank elements
       List<String> indexPath = gmt.getIndexPathList();
+      if (!isValidIndexPath(indexPath)) {
+        LOG.debug("Maintenance task has invalid index_path={}; failing claim", indexPath);
+        return claim.fail().thenApply(v -> true);
+      }
       return resolveIndexDirs(indexPath)
           .thenCompose(dirs -> buildConfigForIndex(dirs, indexPath)
               .thenCompose(cfg -> processMaintenanceTask(mt, cfg, dirs, indexPath)))
@@ -296,6 +316,17 @@ public final class GlobalWorkerRunner implements AutoCloseable {
         .build();
     return db.runAsync(tr -> maintenanceQueue.enqueueIfNotExists(tr, key, gmt))
         .thenApply(x -> null);
+  }
+
+  /**
+   * Returns {@code true} if the index path is non-empty and contains no blank elements.
+   */
+  private static boolean isValidIndexPath(List<String> indexPath) {
+    if (indexPath == null || indexPath.isEmpty()) return false;
+    for (String element : indexPath) {
+      if (element == null || element.isBlank()) return false;
+    }
+    return true;
   }
 
   /**

--- a/src/main/java/io/github/panghy/vectorsearch/tasks/GlobalWorkerRunner.java
+++ b/src/main/java/io/github/panghy/vectorsearch/tasks/GlobalWorkerRunner.java
@@ -1,6 +1,7 @@
 package io.github.panghy.vectorsearch.tasks;
 
 import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.CompletableFuture.allOf;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 
 import com.apple.foundationdb.Database;
@@ -18,6 +19,7 @@ import io.github.panghy.vectorsearch.proto.GlobalBuildTask;
 import io.github.panghy.vectorsearch.proto.GlobalMaintenanceTask;
 import io.github.panghy.vectorsearch.proto.IndexMeta;
 import io.github.panghy.vectorsearch.proto.MaintenanceTask;
+import io.github.panghy.vectorsearch.proto.SegmentMeta;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -192,7 +194,7 @@ public final class GlobalWorkerRunner implements AutoCloseable {
       List<String> indexPath = gmt.getIndexPathList();
       return resolveIndexDirs(indexPath)
           .thenCompose(dirs -> buildConfigForIndex(dirs, indexPath)
-              .thenCompose(cfg -> processMaintenanceTask(mt, cfg, dirs)))
+              .thenCompose(cfg -> processMaintenanceTask(mt, cfg, dirs, indexPath)))
           .handle((v, ex) -> ex)
           .thenCompose(ex -> (ex == null) ? claim.complete() : claim.fail())
           .thenApply(v -> true);
@@ -200,8 +202,11 @@ public final class GlobalWorkerRunner implements AutoCloseable {
   }
 
   private CompletableFuture<Void> processMaintenanceTask(
-      MaintenanceTask t, VectorIndexConfig cfg, IndexDirectories dirs) {
-    MaintenanceService svc = new MaintenanceService(cfg, dirs);
+      MaintenanceTask t, VectorIndexConfig cfg, IndexDirectories dirs, List<String> indexPath) {
+    // Wrap the global maintenance queue so follow-up tasks (e.g. FindCompactionCandidates
+    // after vacuum) stay on the global queue instead of a local per-index queue.
+    GlobalMaintenanceQueueAdapter adapter = new GlobalMaintenanceQueueAdapter(maintenanceQueue, indexPath);
+    MaintenanceService svc = new MaintenanceService(cfg, dirs, adapter);
     if (t.hasVacuum()) {
       var v = t.getVacuum();
       return svc.vacuumSegment(v.getSegId(), v.getMinDeletedRatio());
@@ -210,10 +215,87 @@ public final class GlobalWorkerRunner implements AutoCloseable {
       return svc.compactSegments(t.getCompact().getSegIdsList());
     }
     if (t.hasFindCandidates()) {
-      return svc.findCompactionCandidates(t.getFindCandidates().getAnchorSegId())
-          .thenApply(v -> null);
+      int anchor = t.getFindCandidates().getAnchorSegId();
+      return handleFindCandidates(svc, anchor, cfg, dirs, indexPath);
     }
     return completedFuture(null);
+  }
+
+  /**
+   * Handles {@code FindCompactionCandidates} with the same logic as
+   * {@link MaintenanceWorker}: checks throttle, marks candidates COMPACTING,
+   * and enqueues a {@code Compact} task on the global maintenance queue.
+   */
+  private CompletableFuture<Void> handleFindCandidates(
+      MaintenanceService svc, int anchor, VectorIndexConfig cfg, IndexDirectories dirs, List<String> indexPath) {
+    if (cfg.getMaxConcurrentCompactions() <= 0) return completedFuture(null);
+    return svc.findCompactionCandidates(anchor).thenCompose(cands -> {
+      if (cands.size() <= 1) return completedFuture(null);
+      return svc.countInFlightCompactions()
+          .thenCompose(inflight -> inflight >= cfg.getMaxConcurrentCompactions()
+              ? completedFuture(null)
+              : markCandidatesCompacting(dirs, cands)
+                  .thenCompose(marked -> marked
+                      ? enqueueCompactOnGlobalQueue(cands, indexPath)
+                      : completedFuture(null)));
+    });
+  }
+
+  /**
+   * Atomically marks all candidate segments as COMPACTING if they are all currently SEALED.
+   */
+  private CompletableFuture<Boolean> markCandidatesCompacting(IndexDirectories dirs, List<Integer> cands) {
+    return db.runAsync(tr -> {
+      List<CompletableFuture<byte[]>> metas = new ArrayList<>();
+      for (int sid : cands) metas.add(dirs.segmentKeys(tr, sid).thenCompose(sk -> tr.get(sk.metaKey())));
+      return allOf(metas.toArray(CompletableFuture[]::new)).thenCompose(v -> {
+        for (var f : metas) {
+          byte[] mb = f.getNow(null);
+          if (mb == null) return completedFuture(false);
+          try {
+            var sm = SegmentMeta.parseFrom(mb);
+            if (sm.getState() != SegmentMeta.State.SEALED) return completedFuture(false);
+          } catch (InvalidProtocolBufferException e) {
+            throw new RuntimeException(e);
+          }
+        }
+        List<CompletableFuture<Void>> sets = new ArrayList<>();
+        for (int sid : cands) {
+          sets.add(dirs.segmentKeys(tr, sid)
+              .thenCompose(sk -> tr.get(sk.metaKey()).thenApply(bytes -> {
+                try {
+                  var sm = SegmentMeta.parseFrom(bytes);
+                  var updated = sm.toBuilder()
+                      .setState(SegmentMeta.State.COMPACTING)
+                      .build();
+                  tr.set(sk.metaKey(), updated.toByteArray());
+                  return null;
+                } catch (InvalidProtocolBufferException e) {
+                  throw new RuntimeException(e);
+                }
+              })));
+        }
+        return allOf(sets.toArray(CompletableFuture[]::new)).thenApply(x -> true);
+      });
+    });
+  }
+
+  /**
+   * Enqueues a {@code Compact} task on the global maintenance queue for the given segments.
+   */
+  private CompletableFuture<Void> enqueueCompactOnGlobalQueue(List<Integer> segIds, List<String> indexPath) {
+    List<Integer> sorted = new ArrayList<>(segIds);
+    sorted.sort(Integer::compareTo);
+    String key = "compact:" + sorted;
+    MaintenanceTask.Compact c =
+        MaintenanceTask.Compact.newBuilder().addAllSegIds(sorted).build();
+    MaintenanceTask mt = MaintenanceTask.newBuilder().setCompact(c).build();
+    GlobalMaintenanceTask gmt = GlobalMaintenanceTask.newBuilder()
+        .addAllIndexPath(indexPath)
+        .setTask(mt)
+        .build();
+    return db.runAsync(tr -> maintenanceQueue.enqueueIfNotExists(tr, key, gmt))
+        .thenApply(x -> null);
   }
 
   /**
@@ -228,8 +310,23 @@ public final class GlobalWorkerRunner implements AutoCloseable {
   }
 
   /**
-   * Reads persisted {@link IndexMeta} from the index and reconstructs a {@link VectorIndexConfig}
-   * using data params from the meta and operational settings from the {@link WorkerConfig}.
+   * Reads persisted {@link IndexMeta} from the index and reconstructs a {@link VectorIndexConfig}.
+   *
+   * <p>The built config combines:
+   * <ul>
+   *   <li><b>Data/algorithmic params</b> from {@code IndexMeta}: dimension, metric,
+   *       maxSegmentSize, pqM, pqK, graphDegree, oversample, graphBuildBreadth, graphAlpha
+   *       (falling back to {@link WorkerConfig} defaults when the meta value is zero/unset).</li>
+   *   <li><b>All operational settings</b> from the runner's {@link WorkerConfig}: worker count,
+   *       TTL, throttle, compaction planner, vacuum, build batching, caches, time source,
+   *       and metric attributes.</li>
+   * </ul>
+   *
+   * <p>Local worker threads are forced to zero because the global runner handles dispatch.
+   * The returned config does <em>not</em> carry a {@link
+   * io.github.panghy.vectorsearch.config.GlobalTaskQueueConfig} — callers that need to
+   * route follow-up tasks to the global queue should supply an explicit queue reference
+   * (e.g. via {@link GlobalMaintenanceQueueAdapter}).</p>
    *
    * <p>Package-private for testing.</p>
    */
@@ -250,7 +347,7 @@ public final class GlobalWorkerRunner implements AutoCloseable {
           ? VectorIndexConfig.Metric.COSINE
           : VectorIndexConfig.Metric.L2;
       WorkerConfig wc = workerConfig;
-      // Build config with data params from IndexMeta + ALL operational settings from WorkerConfig
+      // Build config: data params from IndexMeta + operational settings from WorkerConfig
       VectorIndexConfig cfg = VectorIndexConfig.builder(db, dirs.indexDir())
           .dimension(meta.getDimension())
           .metric(metric)
@@ -268,7 +365,7 @@ public final class GlobalWorkerRunner implements AutoCloseable {
           // No local workers for global runner
           .localWorkerThreads(0)
           .localMaintenanceWorkerThreads(0)
-          // ALL operational settings from WorkerConfig
+          // Operational settings from WorkerConfig (local workers disabled)
           .estimatedWorkerCount(wc.getEstimatedWorkerCount())
           .defaultTtl(wc.getDefaultTtl())
           .defaultThrottle(wc.getDefaultThrottle())

--- a/src/main/java/io/github/panghy/vectorsearch/tasks/GlobalWorkerRunner.java
+++ b/src/main/java/io/github/panghy/vectorsearch/tasks/GlobalWorkerRunner.java
@@ -10,6 +10,7 @@ import com.google.protobuf.InvalidProtocolBufferException;
 import io.github.panghy.taskqueue.TaskQueue;
 import io.github.panghy.vectorsearch.config.GlobalTaskQueueConfig;
 import io.github.panghy.vectorsearch.config.VectorIndexConfig;
+import io.github.panghy.vectorsearch.config.WorkerConfig;
 import io.github.panghy.vectorsearch.fdb.FdbDirectories;
 import io.github.panghy.vectorsearch.fdb.FdbDirectories.IndexDirectories;
 import io.github.panghy.vectorsearch.proto.BuildTask;
@@ -49,7 +50,7 @@ public final class GlobalWorkerRunner implements AutoCloseable {
   private static final Logger LOG = LoggerFactory.getLogger(GlobalWorkerRunner.class);
 
   private final Database db;
-  private final VectorIndexConfig templateConfig;
+  private final WorkerConfig workerConfig;
   private final TaskQueue<String, GlobalBuildTask> buildQueue;
   private final TaskQueue<String, GlobalMaintenanceTask> maintenanceQueue;
   private final AtomicBoolean running = new AtomicBoolean(false);
@@ -64,13 +65,13 @@ public final class GlobalWorkerRunner implements AutoCloseable {
   /**
    * Creates a new {@code GlobalWorkerRunner}.
    *
-   * @param db             the FoundationDB database handle
-   * @param templateConfig operational template config (data params are overridden per-index)
-   * @param globalConfig   the global task queue configuration holding both queues
+   * @param db           the FoundationDB database handle
+   * @param workerConfig operational settings applied to every index processed by this runner
+   * @param globalConfig the global task queue configuration holding both queues
    */
-  public GlobalWorkerRunner(Database db, VectorIndexConfig templateConfig, GlobalTaskQueueConfig globalConfig) {
+  public GlobalWorkerRunner(Database db, WorkerConfig workerConfig, GlobalTaskQueueConfig globalConfig) {
     this.db = requireNonNull(db, "db");
-    this.templateConfig = requireNonNull(templateConfig, "templateConfig");
+    this.workerConfig = requireNonNull(workerConfig, "workerConfig");
     requireNonNull(globalConfig, "globalConfig");
     this.buildQueue = globalConfig.getBuildQueue();
     this.maintenanceQueue = globalConfig.getMaintenanceQueue();
@@ -228,9 +229,11 @@ public final class GlobalWorkerRunner implements AutoCloseable {
 
   /**
    * Reads persisted {@link IndexMeta} from the index and reconstructs a {@link VectorIndexConfig}
-   * using data params from the meta and operational settings from the template.
+   * using data params from the meta and operational settings from the {@link WorkerConfig}.
+   *
+   * <p>Package-private for testing.</p>
    */
-  private CompletableFuture<VectorIndexConfig> buildConfigForIndex(IndexDirectories dirs, List<String> indexPath) {
+  CompletableFuture<VectorIndexConfig> buildConfigForIndex(IndexDirectories dirs, List<String> indexPath) {
     return db.readAsync(tr -> tr.get(dirs.metaKey())).thenCompose(metaBytes -> {
       if (metaBytes == null) {
         return CompletableFuture.failedFuture(
@@ -246,33 +249,48 @@ public final class GlobalWorkerRunner implements AutoCloseable {
       VectorIndexConfig.Metric metric = (meta.getMetric() == IndexMeta.Metric.METRIC_COSINE)
           ? VectorIndexConfig.Metric.COSINE
           : VectorIndexConfig.Metric.L2;
-      // Build config with data params from IndexMeta + operational settings from template
+      WorkerConfig wc = workerConfig;
+      // Build config with data params from IndexMeta + ALL operational settings from WorkerConfig
       VectorIndexConfig cfg = VectorIndexConfig.builder(db, dirs.indexDir())
           .dimension(meta.getDimension())
           .metric(metric)
           .maxSegmentSize(
-              meta.getMaxSegmentSize() > 0
-                  ? meta.getMaxSegmentSize()
-                  : templateConfig.getMaxSegmentSize())
-          .pqM(meta.getPqM() > 0 ? meta.getPqM() : templateConfig.getPqM())
-          .pqK(meta.getPqK() > 1 ? meta.getPqK() : templateConfig.getPqK())
-          .graphDegree(meta.getGraphDegree() > 0 ? meta.getGraphDegree() : templateConfig.getGraphDegree())
-          .oversample(meta.getOversample() > 0 ? meta.getOversample() : templateConfig.getOversample())
+              meta.getMaxSegmentSize() > 0 ? meta.getMaxSegmentSize() : wc.getDefaultMaxSegmentSize())
+          .pqM(meta.getPqM() > 0 ? meta.getPqM() : wc.getDefaultPqM())
+          .pqK(meta.getPqK() > 1 ? meta.getPqK() : wc.getDefaultPqK())
+          .graphDegree(meta.getGraphDegree() > 0 ? meta.getGraphDegree() : wc.getDefaultGraphDegree())
+          .oversample(meta.getOversample() > 0 ? meta.getOversample() : wc.getDefaultOversample())
           .graphBuildBreadth(
               meta.getGraphBuildBreadth() > 0
                   ? meta.getGraphBuildBreadth()
-                  : templateConfig.getGraphBuildBreadth())
-          .graphAlpha(meta.getGraphAlpha() > 0 ? meta.getGraphAlpha() : templateConfig.getGraphAlpha())
-          // Operational settings from template
+                  : wc.getDefaultGraphBuildBreadth())
+          .graphAlpha(meta.getGraphAlpha() > 0 ? meta.getGraphAlpha() : wc.getDefaultGraphAlpha())
+          // No local workers for global runner
           .localWorkerThreads(0)
           .localMaintenanceWorkerThreads(0)
-          .estimatedWorkerCount(templateConfig.getEstimatedWorkerCount())
-          .defaultTtl(templateConfig.getDefaultTtl())
-          .defaultThrottle(templateConfig.getDefaultThrottle())
-          .maxConcurrentCompactions(templateConfig.getMaxConcurrentCompactions())
-          .buildTxnLimitBytes(templateConfig.getBuildTxnLimitBytes())
-          .buildTxnSoftLimitRatio(templateConfig.getBuildTxnSoftLimitRatio())
-          .buildSizeCheckEvery(templateConfig.getBuildSizeCheckEvery())
+          // ALL operational settings from WorkerConfig
+          .estimatedWorkerCount(wc.getEstimatedWorkerCount())
+          .defaultTtl(wc.getDefaultTtl())
+          .defaultThrottle(wc.getDefaultThrottle())
+          .maxConcurrentCompactions(wc.getMaxConcurrentCompactions())
+          .buildTxnLimitBytes(wc.getBuildTxnLimitBytes())
+          .buildTxnSoftLimitRatio(wc.getBuildTxnSoftLimitRatio())
+          .buildSizeCheckEvery(wc.getBuildSizeCheckEvery())
+          .vacuumCooldown(wc.getVacuumCooldown())
+          .vacuumMinDeletedRatio(wc.getVacuumMinDeletedRatio())
+          .autoFindCompactionCandidates(wc.isAutoFindCompactionCandidates())
+          .compactionMinSegments(wc.getCompactionMinSegments())
+          .compactionMaxSegments(wc.getCompactionMaxSegments())
+          .compactionMinFragmentation(wc.getCompactionMinFragmentation())
+          .compactionAgeBiasWeight(wc.getCompactionAgeBiasWeight())
+          .compactionSizeBiasWeight(wc.getCompactionSizeBiasWeight())
+          .compactionFragBiasWeight(wc.getCompactionFragBiasWeight())
+          .codebookBatchLoadSize(wc.getCodebookBatchLoadSize())
+          .adjacencyBatchLoadSize(wc.getAdjacencyBatchLoadSize())
+          .prefetchCodebooksEnabled(wc.isPrefetchCodebooksEnabled())
+          .prefetchCodebooksSync(wc.isPrefetchCodebooksSync())
+          .instantSource(wc.getInstantSource())
+          .metricAttributes(wc.getMetricAttributes())
           .build();
       return completedFuture(cfg);
     });

--- a/src/main/java/io/github/panghy/vectorsearch/tasks/GlobalWorkerRunner.java
+++ b/src/main/java/io/github/panghy/vectorsearch/tasks/GlobalWorkerRunner.java
@@ -1,0 +1,285 @@
+package io.github.panghy.vectorsearch.tasks;
+
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.CompletableFuture.completedFuture;
+
+import com.apple.foundationdb.Database;
+import com.apple.foundationdb.async.AsyncUtil;
+import com.apple.foundationdb.directory.DirectoryLayer;
+import com.google.protobuf.InvalidProtocolBufferException;
+import io.github.panghy.taskqueue.TaskQueue;
+import io.github.panghy.vectorsearch.config.GlobalTaskQueueConfig;
+import io.github.panghy.vectorsearch.config.VectorIndexConfig;
+import io.github.panghy.vectorsearch.fdb.FdbDirectories;
+import io.github.panghy.vectorsearch.fdb.FdbDirectories.IndexDirectories;
+import io.github.panghy.vectorsearch.proto.BuildTask;
+import io.github.panghy.vectorsearch.proto.GlobalBuildTask;
+import io.github.panghy.vectorsearch.proto.GlobalMaintenanceTask;
+import io.github.panghy.vectorsearch.proto.IndexMeta;
+import io.github.panghy.vectorsearch.proto.MaintenanceTask;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Standalone worker that claims tasks from global (cross-index) build and maintenance queues
+ * and dispatches them to the appropriate per-index services.
+ *
+ * <p>For each claimed task the runner:
+ * <ol>
+ *   <li>Extracts the {@code index_path} from the wrapper proto.</li>
+ *   <li>Resolves (and caches) the {@link IndexDirectories} for that path.</li>
+ *   <li>Reads the persisted {@link IndexMeta} to reconstruct a {@link VectorIndexConfig}
+ *       with data params from the index and operational settings from the template.</li>
+ *   <li>Delegates to {@link SegmentBuildService} (build) or {@link MaintenanceWorker}-style
+ *       processing (maintenance).</li>
+ * </ol>
+ *
+ * <p>Uses {@link AsyncUtil#whileTrue} for worker loops, matching the pattern of existing
+ * pools like {@link SegmentBuildWorkerPool} and {@link MaintenanceWorkerPool}.</p>
+ *
+ * @see GlobalTaskQueueConfig
+ */
+public final class GlobalWorkerRunner implements AutoCloseable {
+
+  private static final Logger LOG = LoggerFactory.getLogger(GlobalWorkerRunner.class);
+
+  private final Database db;
+  private final VectorIndexConfig templateConfig;
+  private final TaskQueue<String, GlobalBuildTask> buildQueue;
+  private final TaskQueue<String, GlobalMaintenanceTask> maintenanceQueue;
+  private final AtomicBoolean running = new AtomicBoolean(false);
+  private final List<CompletableFuture<Void>> loops = new ArrayList<>();
+  private int buildThreadCount = 0;
+  private int maintThreadCount = 0;
+
+  // Cache IndexDirectories per index path to avoid repeated DirectoryLayer opens.
+  private final ConcurrentHashMap<List<String>, CompletableFuture<IndexDirectories>> indexDirsCache =
+      new ConcurrentHashMap<>();
+
+  /**
+   * Creates a new {@code GlobalWorkerRunner}.
+   *
+   * @param db             the FoundationDB database handle
+   * @param templateConfig operational template config (data params are overridden per-index)
+   * @param globalConfig   the global task queue configuration holding both queues
+   */
+  public GlobalWorkerRunner(Database db, VectorIndexConfig templateConfig, GlobalTaskQueueConfig globalConfig) {
+    this.db = requireNonNull(db, "db");
+    this.templateConfig = requireNonNull(templateConfig, "templateConfig");
+    requireNonNull(globalConfig, "globalConfig");
+    this.buildQueue = globalConfig.getBuildQueue();
+    this.maintenanceQueue = globalConfig.getMaintenanceQueue();
+  }
+
+  /**
+   * Starts {@code buildWorkers} build loops and {@code maintWorkers} maintenance loops.
+   *
+   * <p>No-op if already started or both counts are zero.</p>
+   *
+   * @param buildWorkers number of build worker loops
+   * @param maintWorkers number of maintenance worker loops
+   */
+  public synchronized void start(int buildWorkers, int maintWorkers) {
+    if (running.get()) return;
+    if (buildWorkers <= 0 && maintWorkers <= 0) return;
+    running.set(true);
+    buildThreadCount = Math.max(0, buildWorkers);
+    maintThreadCount = Math.max(0, maintWorkers);
+    LOG.debug("GlobalWorkerRunner starting build={} maint={}", buildThreadCount, maintThreadCount);
+
+    for (int i = 0; i < buildThreadCount; i++) {
+      CompletableFuture<Void> loop = AsyncUtil.whileTrue(() -> {
+        if (!running.get()) return completedFuture(false);
+        return runOnceBuild()
+            .handle((ok, ex) -> {
+              if (ex != null) LOG.debug("Build loop error (will retry)", ex);
+              return true;
+            })
+            .thenApply(x -> running.get());
+      });
+      loops.add(loop);
+    }
+
+    for (int i = 0; i < maintThreadCount; i++) {
+      CompletableFuture<Void> loop = AsyncUtil.whileTrue(() -> {
+        if (!running.get()) return completedFuture(false);
+        return runOnceMaint()
+            .handle((ok, ex) -> {
+              if (ex != null) LOG.debug("Maintenance loop error (will retry)", ex);
+              return true;
+            })
+            .thenApply(x -> running.get());
+      });
+      loops.add(loop);
+    }
+  }
+
+  /** Stops all worker loops and enqueues sentinel tasks to wake blocked workers. */
+  @Override
+  public synchronized void close() {
+    running.set(false);
+    LOG.debug(
+        "GlobalWorkerRunner stopping; signaling sentinels build={} maint={}",
+        buildThreadCount,
+        maintThreadCount);
+    // Build sentinels
+    for (int i = 0; i < buildThreadCount; i++) {
+      String key = "global-build:-1:shutdown:" + i + ":" + System.nanoTime();
+      GlobalBuildTask sentinel = GlobalBuildTask.newBuilder()
+          .setTask(BuildTask.newBuilder().setSegId(-1).build())
+          .build();
+      buildQueue.enqueueIfNotExists(key, sentinel).exceptionally(ex -> null);
+    }
+    // Maintenance sentinels
+    for (int i = 0; i < maintThreadCount; i++) {
+      String key = "global-maint:-1:shutdown:" + i + ":" + System.nanoTime();
+      GlobalMaintenanceTask sentinel = GlobalMaintenanceTask.newBuilder()
+          .setTask(MaintenanceTask.newBuilder()
+              .setVacuum(MaintenanceTask.Vacuum.newBuilder()
+                  .setSegId(-1)
+                  .build())
+              .build())
+          .build();
+      maintenanceQueue.enqueueIfNotExists(key, sentinel).exceptionally(ex -> null);
+    }
+    loops.clear();
+  }
+
+  /**
+   * Claims and processes a single global build task.
+   *
+   * @return future completing with {@code true} if a task was processed
+   */
+  CompletableFuture<Boolean> runOnceBuild() {
+    return buildQueue.awaitAndClaimTask().thenCompose(claim -> {
+      GlobalBuildTask gbt = claim.task();
+      BuildTask bt = gbt.getTask();
+      // Sentinel: seg_id < 0 means shutdown signal
+      if (bt.getSegId() < 0) {
+        return claim.complete().thenApply(v -> true);
+      }
+      List<String> indexPath = gbt.getIndexPathList();
+      return resolveIndexDirs(indexPath)
+          .thenCompose(dirs -> buildConfigForIndex(dirs, indexPath).thenCompose(cfg -> {
+            SegmentBuildService svc = new SegmentBuildService(cfg, dirs);
+            return svc.build(bt.getSegId());
+          }))
+          .handle((v, ex) -> ex)
+          .thenCompose(ex -> (ex == null) ? claim.complete() : claim.fail())
+          .thenApply(v -> true);
+    });
+  }
+
+  /**
+   * Claims and processes a single global maintenance task.
+   *
+   * @return future completing with {@code true} if a task was processed
+   */
+  CompletableFuture<Boolean> runOnceMaint() {
+    return maintenanceQueue.awaitAndClaimTask().thenCompose(claim -> {
+      GlobalMaintenanceTask gmt = claim.task();
+      MaintenanceTask mt = gmt.getTask();
+      // Sentinel: vacuum with seg_id < 0 means shutdown signal
+      if (mt.hasVacuum() && mt.getVacuum().getSegId() < 0) {
+        return claim.complete().thenApply(v -> true);
+      }
+      List<String> indexPath = gmt.getIndexPathList();
+      return resolveIndexDirs(indexPath)
+          .thenCompose(dirs -> buildConfigForIndex(dirs, indexPath)
+              .thenCompose(cfg -> processMaintenanceTask(mt, cfg, dirs)))
+          .handle((v, ex) -> ex)
+          .thenCompose(ex -> (ex == null) ? claim.complete() : claim.fail())
+          .thenApply(v -> true);
+    });
+  }
+
+  private CompletableFuture<Void> processMaintenanceTask(
+      MaintenanceTask t, VectorIndexConfig cfg, IndexDirectories dirs) {
+    MaintenanceService svc = new MaintenanceService(cfg, dirs);
+    if (t.hasVacuum()) {
+      var v = t.getVacuum();
+      return svc.vacuumSegment(v.getSegId(), v.getMinDeletedRatio());
+    }
+    if (t.hasCompact()) {
+      return svc.compactSegments(t.getCompact().getSegIdsList());
+    }
+    if (t.hasFindCandidates()) {
+      return svc.findCompactionCandidates(t.getFindCandidates().getAnchorSegId())
+          .thenApply(v -> null);
+    }
+    return completedFuture(null);
+  }
+
+  /**
+   * Resolves and caches {@link IndexDirectories} for the given index path.
+   */
+  private CompletableFuture<IndexDirectories> resolveIndexDirs(List<String> indexPath) {
+    return indexDirsCache.computeIfAbsent(
+        List.copyOf(indexPath),
+        path -> DirectoryLayer.getDefault()
+            .open(db, path)
+            .thenCompose(indexDir -> FdbDirectories.openIndex(indexDir, db)));
+  }
+
+  /**
+   * Reads persisted {@link IndexMeta} from the index and reconstructs a {@link VectorIndexConfig}
+   * using data params from the meta and operational settings from the template.
+   */
+  private CompletableFuture<VectorIndexConfig> buildConfigForIndex(IndexDirectories dirs, List<String> indexPath) {
+    return db.readAsync(tr -> tr.get(dirs.metaKey())).thenCompose(metaBytes -> {
+      if (metaBytes == null) {
+        return CompletableFuture.failedFuture(
+            new IllegalStateException("No IndexMeta found for path: " + indexPath));
+      }
+      IndexMeta meta;
+      try {
+        meta = IndexMeta.parseFrom(metaBytes);
+      } catch (InvalidProtocolBufferException e) {
+        return CompletableFuture.failedFuture(
+            new IllegalStateException("Corrupted IndexMeta at path: " + indexPath, e));
+      }
+      VectorIndexConfig.Metric metric = (meta.getMetric() == IndexMeta.Metric.METRIC_COSINE)
+          ? VectorIndexConfig.Metric.COSINE
+          : VectorIndexConfig.Metric.L2;
+      // Build config with data params from IndexMeta + operational settings from template
+      VectorIndexConfig cfg = VectorIndexConfig.builder(db, dirs.indexDir())
+          .dimension(meta.getDimension())
+          .metric(metric)
+          .maxSegmentSize(
+              meta.getMaxSegmentSize() > 0
+                  ? meta.getMaxSegmentSize()
+                  : templateConfig.getMaxSegmentSize())
+          .pqM(meta.getPqM() > 0 ? meta.getPqM() : templateConfig.getPqM())
+          .pqK(meta.getPqK() > 1 ? meta.getPqK() : templateConfig.getPqK())
+          .graphDegree(meta.getGraphDegree() > 0 ? meta.getGraphDegree() : templateConfig.getGraphDegree())
+          .oversample(meta.getOversample() > 0 ? meta.getOversample() : templateConfig.getOversample())
+          .graphBuildBreadth(
+              meta.getGraphBuildBreadth() > 0
+                  ? meta.getGraphBuildBreadth()
+                  : templateConfig.getGraphBuildBreadth())
+          .graphAlpha(meta.getGraphAlpha() > 0 ? meta.getGraphAlpha() : templateConfig.getGraphAlpha())
+          // Operational settings from template
+          .localWorkerThreads(0)
+          .localMaintenanceWorkerThreads(0)
+          .estimatedWorkerCount(templateConfig.getEstimatedWorkerCount())
+          .defaultTtl(templateConfig.getDefaultTtl())
+          .defaultThrottle(templateConfig.getDefaultThrottle())
+          .maxConcurrentCompactions(templateConfig.getMaxConcurrentCompactions())
+          .buildTxnLimitBytes(templateConfig.getBuildTxnLimitBytes())
+          .buildTxnSoftLimitRatio(templateConfig.getBuildTxnSoftLimitRatio())
+          .buildSizeCheckEvery(templateConfig.getBuildSizeCheckEvery())
+          .build();
+      return completedFuture(cfg);
+    });
+  }
+
+  /** Returns {@code true} if the runner is currently active. Visible for testing. */
+  boolean isRunning() {
+    return running.get();
+  }
+}

--- a/src/main/java/io/github/panghy/vectorsearch/tasks/GlobalWorkerRunner.java
+++ b/src/main/java/io/github/panghy/vectorsearch/tasks/GlobalWorkerRunner.java
@@ -306,7 +306,7 @@ public final class GlobalWorkerRunner implements AutoCloseable {
   private CompletableFuture<Void> enqueueCompactOnGlobalQueue(List<Integer> segIds, List<String> indexPath) {
     List<Integer> sorted = new ArrayList<>(segIds);
     sorted.sort(Integer::compareTo);
-    String key = "compact:" + sorted;
+    String key = String.join("/", indexPath) + ":compact:" + sorted;
     MaintenanceTask.Compact c =
         MaintenanceTask.Compact.newBuilder().addAllSegIds(sorted).build();
     MaintenanceTask mt = MaintenanceTask.newBuilder().setCompact(c).build();

--- a/src/main/java/io/github/panghy/vectorsearch/tasks/MaintenanceService.java
+++ b/src/main/java/io/github/panghy/vectorsearch/tasks/MaintenanceService.java
@@ -58,6 +58,23 @@ public final class MaintenanceService {
   }
 
   /**
+   * Creates a {@code MaintenanceService} that routes follow-up maintenance tasks (e.g.
+   * {@code FindCompactionCandidates} after vacuum) to the supplied queue instead of
+   * creating a local per-index queue. Use this constructor in global-queue mode so that
+   * follow-up work stays on the shared global maintenance queue.
+   *
+   * @param cfg   index configuration
+   * @param dirs  index directories
+   * @param queue pre-existing maintenance queue (typically a {@link GlobalMaintenanceQueueAdapter})
+   */
+  public MaintenanceService(
+      VectorIndexConfig cfg, FdbDirectories.IndexDirectories dirs, TaskQueue<String, MaintenanceTask> queue) {
+    this.config = requireNonNull(cfg, "config");
+    this.indexDirs = requireNonNull(dirs, "indexDirs");
+    this.maintQueue = CompletableFuture.completedFuture(requireNonNull(queue, "queue"));
+  }
+
+  /**
    * Vacuum a single segment: remove tombstoned vector records, PQ codes, and adjacency entries.
    *
    * <p>If {@code minDeletedRatio} is greater than zero, the method first checks the

--- a/src/main/java/io/github/panghy/vectorsearch/tasks/ProtoSerializers.java
+++ b/src/main/java/io/github/panghy/vectorsearch/tasks/ProtoSerializers.java
@@ -3,10 +3,15 @@ package io.github.panghy.vectorsearch.tasks;
 import com.google.protobuf.ByteString;
 import io.github.panghy.taskqueue.TaskQueueConfig;
 import io.github.panghy.vectorsearch.proto.BuildTask;
+import io.github.panghy.vectorsearch.proto.GlobalBuildTask;
+import io.github.panghy.vectorsearch.proto.GlobalMaintenanceTask;
 import io.github.panghy.vectorsearch.proto.MaintenanceTask;
 import java.nio.charset.StandardCharsets;
 
-/** Utility TaskQueue serializers for {@link BuildTask} and String keys. */
+/**
+ * Utility TaskQueue serializers for {@link BuildTask}, {@link MaintenanceTask},
+ * {@link GlobalBuildTask}, {@link GlobalMaintenanceTask}, and String keys.
+ */
 public final class ProtoSerializers {
   private ProtoSerializers() {}
 
@@ -65,6 +70,49 @@ public final class ProtoSerializers {
         return bytes == null ? MaintenanceTask.getDefaultInstance() : MaintenanceTask.parseFrom(bytes);
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
         throw new IllegalArgumentException("Failed to parse MaintenanceTask", e);
+      }
+    }
+  }
+
+  /** Protobuf serializer for {@link GlobalBuildTask} payloads. */
+  public static final class GlobalBuildTaskSerializer implements TaskQueueConfig.TaskSerializer<GlobalBuildTask> {
+    /** Serializes a {@link GlobalBuildTask} into a {@link ByteString}. */
+    @Override
+    public ByteString serialize(GlobalBuildTask value) {
+      if (value == null) return ByteString.EMPTY;
+      return value.toByteString();
+    }
+
+    /** Deserializes a {@link GlobalBuildTask} from binary form. */
+    @Override
+    public GlobalBuildTask deserialize(ByteString bytes) {
+      try {
+        return bytes == null ? GlobalBuildTask.getDefaultInstance() : GlobalBuildTask.parseFrom(bytes);
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw new IllegalArgumentException("Failed to parse GlobalBuildTask", e);
+      }
+    }
+  }
+
+  /** Protobuf serializer for {@link GlobalMaintenanceTask} payloads. */
+  public static final class GlobalMaintenanceTaskSerializer
+      implements TaskQueueConfig.TaskSerializer<GlobalMaintenanceTask> {
+    /** Serializes a {@link GlobalMaintenanceTask} into a {@link ByteString}. */
+    @Override
+    public ByteString serialize(GlobalMaintenanceTask value) {
+      if (value == null) return ByteString.EMPTY;
+      return value.toByteString();
+    }
+
+    /** Deserializes a {@link GlobalMaintenanceTask} from binary form. */
+    @Override
+    public GlobalMaintenanceTask deserialize(ByteString bytes) {
+      try {
+        return bytes == null
+            ? GlobalMaintenanceTask.getDefaultInstance()
+            : GlobalMaintenanceTask.parseFrom(bytes);
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw new IllegalArgumentException("Failed to parse GlobalMaintenanceTask", e);
       }
     }
   }

--- a/src/main/proto/vectorsearch.proto
+++ b/src/main/proto/vectorsearch.proto
@@ -193,3 +193,26 @@ message MaintenanceTask {
     int32 anchor_seg_id = 1;
   }
 }
+
+
+// -----------------------------------------------------------------------------
+// Global task wrappers
+// -----------------------------------------------------------------------------
+// These messages wrap per-index tasks with the index directory path so that
+// global (cross-index) workers can route tasks to the correct index.
+
+// Wraps a BuildTask with the index directory path for global task queues.
+message GlobalBuildTask {
+  // Path components of the index directory (e.g. ["vectorsearch", "my-index"]).
+  repeated string index_path = 1;
+  // The original per-index build task payload.
+  BuildTask task = 2;
+}
+
+// Wraps a MaintenanceTask with the index directory path for global task queues.
+message GlobalMaintenanceTask {
+  // Path components of the index directory (e.g. ["vectorsearch", "my-index"]).
+  repeated string index_path = 1;
+  // The original per-index maintenance task payload.
+  MaintenanceTask task = 2;
+}

--- a/src/test/java/io/github/panghy/vectorsearch/config/VectorIndexConfigValidationTest.java
+++ b/src/test/java/io/github/panghy/vectorsearch/config/VectorIndexConfigValidationTest.java
@@ -246,6 +246,88 @@ class VectorIndexConfigValidationTest {
     org.assertj.core.api.Assertions.assertThat(cfg.getDefaultTtl()).isEqualTo(Duration.ofMinutes(5));
   }
 
+  // ---- VectorIndexConfig null Duration checks ----
+
+  @Test
+  void vectorIndexConfig_rejectsNullVacuumCooldown() {
+    assertThatThrownBy(() -> VectorIndexConfig.builder(db, root)
+            .dimension(4)
+            .vacuumCooldown(null)
+            .build())
+        .isInstanceOf(NullPointerException.class)
+        .hasMessageContaining("vacuumCooldown");
+  }
+
+  @Test
+  void vectorIndexConfig_rejectsNullDefaultThrottle() {
+    assertThatThrownBy(() -> VectorIndexConfig.builder(db, root)
+            .dimension(4)
+            .defaultThrottle(null)
+            .build())
+        .isInstanceOf(NullPointerException.class)
+        .hasMessageContaining("defaultThrottle");
+  }
+
+  // ---- WorkerConfig data-format fallback default validation tests ----
+
+  @Test
+  void workerConfig_rejectsInvalidDefaultMaxSegmentSize() {
+    assertThatThrownBy(() -> WorkerConfig.builder().defaultMaxSegmentSize(0).build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("defaultMaxSegmentSize");
+    assertThatThrownBy(
+            () -> WorkerConfig.builder().defaultMaxSegmentSize(-1).build())
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void workerConfig_rejectsInvalidDefaultPqM() {
+    assertThatThrownBy(() -> WorkerConfig.builder().defaultPqM(0).build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("defaultPqM");
+  }
+
+  @Test
+  void workerConfig_rejectsInvalidDefaultPqK() {
+    assertThatThrownBy(() -> WorkerConfig.builder().defaultPqK(1).build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("defaultPqK");
+    assertThatThrownBy(() -> WorkerConfig.builder().defaultPqK(0).build())
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void workerConfig_rejectsInvalidDefaultGraphDegree() {
+    assertThatThrownBy(() -> WorkerConfig.builder().defaultGraphDegree(0).build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("defaultGraphDegree");
+  }
+
+  @Test
+  void workerConfig_rejectsInvalidDefaultOversample() {
+    assertThatThrownBy(() -> WorkerConfig.builder().defaultOversample(0).build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("defaultOversample");
+  }
+
+  @Test
+  void workerConfig_rejectsInvalidDefaultGraphBuildBreadth() {
+    // defaultGraphBuildBreadth must be >= defaultGraphDegree
+    assertThatThrownBy(() -> WorkerConfig.builder()
+            .defaultGraphDegree(64)
+            .defaultGraphBuildBreadth(32)
+            .build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("defaultGraphBuildBreadth");
+  }
+
+  @Test
+  void workerConfig_rejectsNegativeDefaultGraphAlpha() {
+    assertThatThrownBy(() -> WorkerConfig.builder().defaultGraphAlpha(-0.1).build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("defaultGraphAlpha");
+  }
+
   @Test
   void vectorIndexConfig_rejectsInvalidPrebuiltWorkerConfig() {
     // When a pre-built WorkerConfig with invalid values is supplied to VectorIndexConfig,

--- a/src/test/java/io/github/panghy/vectorsearch/config/VectorIndexConfigValidationTest.java
+++ b/src/test/java/io/github/panghy/vectorsearch/config/VectorIndexConfigValidationTest.java
@@ -86,4 +86,190 @@ class VectorIndexConfigValidationTest {
             .build())
         .isInstanceOf(IllegalArgumentException.class);
   }
+
+  // ---- WorkerConfig.Builder validation tests ----
+
+  @Test
+  void workerConfig_rejectsInvalidEstimatedWorkerCount() {
+    assertThatThrownBy(() -> WorkerConfig.builder().estimatedWorkerCount(0).build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("estimatedWorkerCount");
+    assertThatThrownBy(() -> WorkerConfig.builder().estimatedWorkerCount(-1).build())
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void workerConfig_rejectsInvalidDefaultTtl() {
+    assertThatThrownBy(
+            () -> WorkerConfig.builder().defaultTtl(Duration.ZERO).build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("defaultTtl");
+    assertThatThrownBy(() -> WorkerConfig.builder()
+            .defaultTtl(Duration.ofSeconds(-1))
+            .build())
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> WorkerConfig.builder().defaultTtl(null).build())
+        .isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  void workerConfig_rejectsNegativeDefaultThrottle() {
+    assertThatThrownBy(() -> WorkerConfig.builder()
+            .defaultThrottle(Duration.ofSeconds(-1))
+            .build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("defaultThrottle");
+  }
+
+  @Test
+  void workerConfig_rejectsNegativeMaxConcurrentCompactions() {
+    assertThatThrownBy(() ->
+            WorkerConfig.builder().maxConcurrentCompactions(-1).build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("maxConcurrentCompactions");
+  }
+
+  @Test
+  void workerConfig_rejectsInvalidVacuumCooldown() {
+    assertThatThrownBy(() -> WorkerConfig.builder()
+            .vacuumCooldown(Duration.ofSeconds(-1))
+            .build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("vacuumCooldown");
+  }
+
+  @Test
+  void workerConfig_rejectsInvalidVacuumMinDeletedRatio() {
+    assertThatThrownBy(
+            () -> WorkerConfig.builder().vacuumMinDeletedRatio(-0.1).build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("vacuumMinDeletedRatio");
+    assertThatThrownBy(
+            () -> WorkerConfig.builder().vacuumMinDeletedRatio(1.1).build())
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void workerConfig_rejectsInvalidBuildTxnLimitBytes() {
+    assertThatThrownBy(() -> WorkerConfig.builder().buildTxnLimitBytes(0).build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("buildTxnLimitBytes");
+    assertThatThrownBy(() -> WorkerConfig.builder().buildTxnLimitBytes(-1).build())
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void workerConfig_rejectsInvalidBuildTxnSoftLimitRatio() {
+    assertThatThrownBy(
+            () -> WorkerConfig.builder().buildTxnSoftLimitRatio(0.0).build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("buildTxnSoftLimitRatio");
+    assertThatThrownBy(
+            () -> WorkerConfig.builder().buildTxnSoftLimitRatio(1.0).build())
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void workerConfig_rejectsInvalidBuildSizeCheckEvery() {
+    assertThatThrownBy(() -> WorkerConfig.builder().buildSizeCheckEvery(0).build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("buildSizeCheckEvery");
+  }
+
+  @Test
+  void workerConfig_rejectsInvalidBatchLoadSizes() {
+    assertThatThrownBy(() -> WorkerConfig.builder().codebookBatchLoadSize(0).build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("codebookBatchLoadSize");
+    assertThatThrownBy(
+            () -> WorkerConfig.builder().adjacencyBatchLoadSize(0).build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("adjacencyBatchLoadSize");
+  }
+
+  @Test
+  void workerConfig_rejectsInvalidCompactionMinSegments() {
+    assertThatThrownBy(() -> WorkerConfig.builder().compactionMinSegments(1).build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("compactionMinSegments");
+  }
+
+  @Test
+  void workerConfig_rejectsInvalidCompactionMaxSegments() {
+    assertThatThrownBy(() -> WorkerConfig.builder()
+            .compactionMinSegments(4)
+            .compactionMaxSegments(3)
+            .build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("compactionMaxSegments");
+  }
+
+  @Test
+  void workerConfig_rejectsInvalidCompactionMinFragmentation() {
+    assertThatThrownBy(() ->
+            WorkerConfig.builder().compactionMinFragmentation(-0.1).build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("compactionMinFragmentation");
+    assertThatThrownBy(() ->
+            WorkerConfig.builder().compactionMinFragmentation(1.1).build())
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void workerConfig_rejectsNegativeCompactionBiasWeights() {
+    assertThatThrownBy(() ->
+            WorkerConfig.builder().compactionAgeBiasWeight(-0.1).build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("compactionAgeBiasWeight");
+    assertThatThrownBy(() ->
+            WorkerConfig.builder().compactionSizeBiasWeight(-0.1).build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("compactionSizeBiasWeight");
+    assertThatThrownBy(() ->
+            WorkerConfig.builder().compactionFragBiasWeight(-0.1).build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("compactionFragBiasWeight");
+  }
+
+  @Test
+  void workerConfig_rejectsNullInstantSource() {
+    assertThatThrownBy(() -> WorkerConfig.builder().instantSource(null).build())
+        .isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  void workerConfig_defaultsAreValid() {
+    // Default builder should produce a valid WorkerConfig without throwing
+    WorkerConfig cfg = WorkerConfig.builder().build();
+    org.assertj.core.api.Assertions.assertThat(cfg.getEstimatedWorkerCount())
+        .isEqualTo(1);
+    org.assertj.core.api.Assertions.assertThat(cfg.getDefaultTtl()).isEqualTo(Duration.ofMinutes(5));
+  }
+
+  @Test
+  void vectorIndexConfig_rejectsInvalidPrebuiltWorkerConfig() {
+    // When a pre-built WorkerConfig with invalid values is supplied to VectorIndexConfig,
+    // the WorkerConfig.Builder.build() should reject it before it reaches VectorIndexConfig
+    assertThatThrownBy(() -> {
+          WorkerConfig bad =
+              WorkerConfig.builder().estimatedWorkerCount(0).build();
+          VectorIndexConfig.builder(db, root)
+              .dimension(4)
+              .workerConfig(bad)
+              .build();
+        })
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("estimatedWorkerCount");
+
+    assertThatThrownBy(() -> {
+          WorkerConfig bad =
+              WorkerConfig.builder().buildTxnSoftLimitRatio(0.0).build();
+          VectorIndexConfig.builder(db, root)
+              .dimension(4)
+              .workerConfig(bad)
+              .build();
+        })
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("buildTxnSoftLimitRatio");
+  }
 }

--- a/src/test/java/io/github/panghy/vectorsearch/tasks/GlobalTaskQueueEdgeCaseTest.java
+++ b/src/test/java/io/github/panghy/vectorsearch/tasks/GlobalTaskQueueEdgeCaseTest.java
@@ -170,7 +170,9 @@ class GlobalTaskQueueEdgeCaseTest {
     BuildTask bt = BuildTask.newBuilder().setSegId(7).build();
     db.runAsync(tr -> adapter.enqueue(tr, "key2", bt, Duration.ofSeconds(10), Duration.ofMillis(50)))
         .get(5, TimeUnit.SECONDS);
-    var claim = globalBuildQueue.awaitAndClaimTask(db).get(10, TimeUnit.SECONDS);
+    // Allow throttle to elapse before claiming to avoid flakiness under concurrent FDB load
+    Thread.sleep(200);
+    var claim = globalBuildQueue.awaitAndClaimTask(db).get(30, TimeUnit.SECONDS);
     assertThat(claim.task().getIndexPathList()).containsExactly("my", "index");
     assertThat(claim.task().getTask().getSegId()).isEqualTo(7);
     claim.complete().get(5, TimeUnit.SECONDS);

--- a/src/test/java/io/github/panghy/vectorsearch/tasks/GlobalTaskQueueEdgeCaseTest.java
+++ b/src/test/java/io/github/panghy/vectorsearch/tasks/GlobalTaskQueueEdgeCaseTest.java
@@ -14,7 +14,9 @@ import io.github.panghy.taskqueue.TaskQueues;
 import io.github.panghy.vectorsearch.api.VectorIndex;
 import io.github.panghy.vectorsearch.config.GlobalTaskQueueConfig;
 import io.github.panghy.vectorsearch.config.VectorIndexConfig;
+import io.github.panghy.vectorsearch.config.WorkerConfig;
 import io.github.panghy.vectorsearch.fdb.FdbDirectories;
+import io.github.panghy.vectorsearch.fdb.FdbDirectories.IndexDirectories;
 import io.github.panghy.vectorsearch.proto.BuildTask;
 import io.github.panghy.vectorsearch.proto.GlobalBuildTask;
 import io.github.panghy.vectorsearch.proto.GlobalMaintenanceTask;
@@ -221,13 +223,8 @@ class GlobalTaskQueueEdgeCaseTest {
   // ---- Test 7: start(0,0) is no-op ----
   @Test
   void workerRunner_startZeroZero_isNoOp() {
-    VectorIndexConfig templateCfg = VectorIndexConfig.builder(db, root)
-        .dimension(4)
-        .pqM(2)
-        .pqK(8)
-        .graphDegree(4)
-        .build();
-    runner = new GlobalWorkerRunner(db, templateCfg, globalConfig);
+    WorkerConfig workerCfg = WorkerConfig.builder().build();
+    runner = new GlobalWorkerRunner(db, workerCfg, globalConfig);
     runner.start(0, 0);
     assertThat(runner.isRunning()).isFalse();
   }
@@ -235,13 +232,8 @@ class GlobalTaskQueueEdgeCaseTest {
   // ---- Test 8: double start is idempotent ----
   @Test
   void workerRunner_doubleStart_isIdempotent() {
-    VectorIndexConfig templateCfg = VectorIndexConfig.builder(db, root)
-        .dimension(4)
-        .pqM(2)
-        .pqK(8)
-        .graphDegree(4)
-        .build();
-    runner = new GlobalWorkerRunner(db, templateCfg, globalConfig);
+    WorkerConfig workerCfg = WorkerConfig.builder().build();
+    runner = new GlobalWorkerRunner(db, workerCfg, globalConfig);
     runner.start(1, 0);
     assertThat(runner.isRunning()).isTrue();
     // Second start should be no-op
@@ -252,13 +244,8 @@ class GlobalTaskQueueEdgeCaseTest {
   // ---- Test 9: close sets isRunning to false ----
   @Test
   void workerRunner_close_setsIsRunningFalse() {
-    VectorIndexConfig templateCfg = VectorIndexConfig.builder(db, root)
-        .dimension(4)
-        .pqM(2)
-        .pqK(8)
-        .graphDegree(4)
-        .build();
-    runner = new GlobalWorkerRunner(db, templateCfg, globalConfig);
+    WorkerConfig workerCfg = WorkerConfig.builder().build();
+    runner = new GlobalWorkerRunner(db, workerCfg, globalConfig);
     runner.start(1, 1);
     assertThat(runner.isRunning()).isTrue();
     runner.close();
@@ -269,13 +256,8 @@ class GlobalTaskQueueEdgeCaseTest {
   // ---- Test 10: Build sentinel is claimed and completed ----
   @Test
   void workerRunner_buildSentinel_claimedAndCompleted() throws Exception {
-    VectorIndexConfig templateCfg = VectorIndexConfig.builder(db, root)
-        .dimension(4)
-        .pqM(2)
-        .pqK(8)
-        .graphDegree(4)
-        .build();
-    runner = new GlobalWorkerRunner(db, templateCfg, globalConfig);
+    WorkerConfig workerCfg = WorkerConfig.builder().build();
+    runner = new GlobalWorkerRunner(db, workerCfg, globalConfig);
     // Enqueue a build sentinel
     GlobalBuildTask sentinel = GlobalBuildTask.newBuilder()
         .setTask(BuildTask.newBuilder().setSegId(-1).build())
@@ -289,13 +271,8 @@ class GlobalTaskQueueEdgeCaseTest {
   // ---- Test 11: Maintenance sentinel is claimed and completed ----
   @Test
   void workerRunner_maintSentinel_claimedAndCompleted() throws Exception {
-    VectorIndexConfig templateCfg = VectorIndexConfig.builder(db, root)
-        .dimension(4)
-        .pqM(2)
-        .pqK(8)
-        .graphDegree(4)
-        .build();
-    runner = new GlobalWorkerRunner(db, templateCfg, globalConfig);
+    WorkerConfig workerCfg = WorkerConfig.builder().build();
+    runner = new GlobalWorkerRunner(db, workerCfg, globalConfig);
     // Enqueue a maintenance sentinel
     GlobalMaintenanceTask sentinel = GlobalMaintenanceTask.newBuilder()
         .setTask(MaintenanceTask.newBuilder()
@@ -443,16 +420,11 @@ class GlobalTaskQueueEdgeCaseTest {
     assertThat(meta.getGraphDegree()).isEqualTo(64);
 
     // Create a template with different data params — worker should use IndexMeta's params
-    VectorIndexConfig templateCfg = VectorIndexConfig.builder(db, root)
-        .dimension(4)
-        .pqM(2)
-        .pqK(8)
-        .graphDegree(4)
-        .maxSegmentSize(2)
+    WorkerConfig workerCfg = WorkerConfig.builder()
         .estimatedWorkerCount(1)
         .defaultTtl(Duration.ofSeconds(30))
         .build();
-    runner = new GlobalWorkerRunner(db, templateCfg, globalConfig);
+    runner = new GlobalWorkerRunner(db, workerCfg, globalConfig);
     // Process the build task — should succeed using IndexMeta's dimension=16
     runner.runOnceBuild().get(30, TimeUnit.SECONDS);
   }
@@ -478,13 +450,8 @@ class GlobalTaskQueueEdgeCaseTest {
           .build();
       globalBuildQueue.enqueueIfNotExists("missing-meta-task", task).get(5, TimeUnit.SECONDS);
 
-      VectorIndexConfig templateCfg = VectorIndexConfig.builder(db, root)
-          .dimension(4)
-          .pqM(2)
-          .pqK(8)
-          .graphDegree(4)
-          .build();
-      runner = new GlobalWorkerRunner(db, templateCfg, globalConfig);
+      WorkerConfig workerCfg = WorkerConfig.builder().build();
+      runner = new GlobalWorkerRunner(db, workerCfg, globalConfig);
 
       // runOnceBuild should fail the task (not crash the runner)
       // The task will be claimed, fail due to missing IndexMeta, and be marked failed
@@ -496,5 +463,91 @@ class GlobalTaskQueueEdgeCaseTest {
         return null;
       });
     }
+  }
+
+  // ---- Test: buildConfigForIndex applies ALL operational fields from WorkerConfig ----
+  @Test
+  void buildConfigForIndex_appliesAllOperationalFieldsFromWorkerConfig() throws Exception {
+    // Create an index with specific data-format params
+    VectorIndexConfig cfg = VectorIndexConfig.builder(db, root)
+        .dimension(4)
+        .pqM(2)
+        .pqK(8)
+        .graphDegree(4)
+        .maxSegmentSize(2)
+        .globalTaskQueueConfig(globalConfig)
+        .build();
+    index = VectorIndex.createOrOpen(cfg).get(10, TimeUnit.SECONDS);
+
+    // Insert vectors to trigger rotation and create a build task
+    index.add(new float[] {1, 0, 0, 0}, null).get(5, TimeUnit.SECONDS);
+    index.add(new float[] {0, 1, 0, 0}, null).get(5, TimeUnit.SECONDS);
+    index.add(new float[] {0, 0, 1, 0}, null).get(5, TimeUnit.SECONDS);
+
+    // Create a WorkerConfig with non-default operational settings
+    WorkerConfig workerCfg = WorkerConfig.builder()
+        .estimatedWorkerCount(3)
+        .defaultTtl(Duration.ofMinutes(10))
+        .defaultThrottle(Duration.ofSeconds(5))
+        .maxConcurrentCompactions(4)
+        .buildTxnLimitBytes(5_000_000L)
+        .buildTxnSoftLimitRatio(0.8)
+        .buildSizeCheckEvery(16)
+        .vacuumCooldown(Duration.ofSeconds(30))
+        .vacuumMinDeletedRatio(0.5)
+        .autoFindCompactionCandidates(false)
+        .compactionMinSegments(3)
+        .compactionMaxSegments(6)
+        .compactionMinFragmentation(0.2)
+        .compactionAgeBiasWeight(0.4)
+        .compactionSizeBiasWeight(0.4)
+        .compactionFragBiasWeight(0.2)
+        .codebookBatchLoadSize(5_000)
+        .adjacencyBatchLoadSize(3_000)
+        .prefetchCodebooksEnabled(false)
+        .prefetchCodebooksSync(true)
+        .metricAttribute("env", "test")
+        .build();
+
+    runner = new GlobalWorkerRunner(db, workerCfg, globalConfig);
+
+    // Resolve index dirs and call buildConfigForIndex directly
+    IndexDirectories dirs = FdbDirectories.openIndex(root, db).get(5, TimeUnit.SECONDS);
+    VectorIndexConfig reconstructed =
+        runner.buildConfigForIndex(dirs, root.getPath()).get(5, TimeUnit.SECONDS);
+
+    // Assert ALL operational fields match the WorkerConfig
+    assertThat(reconstructed.getEstimatedWorkerCount()).isEqualTo(3);
+    assertThat(reconstructed.getDefaultTtl()).isEqualTo(Duration.ofMinutes(10));
+    assertThat(reconstructed.getDefaultThrottle()).isEqualTo(Duration.ofSeconds(5));
+    assertThat(reconstructed.getMaxConcurrentCompactions()).isEqualTo(4);
+    assertThat(reconstructed.getBuildTxnLimitBytes()).isEqualTo(5_000_000L);
+    assertThat(reconstructed.getBuildTxnSoftLimitRatio()).isEqualTo(0.8);
+    assertThat(reconstructed.getBuildSizeCheckEvery()).isEqualTo(16);
+    assertThat(reconstructed.getVacuumCooldown()).isEqualTo(Duration.ofSeconds(30));
+    assertThat(reconstructed.getVacuumMinDeletedRatio()).isEqualTo(0.5);
+    assertThat(reconstructed.isAutoFindCompactionCandidates()).isFalse();
+    assertThat(reconstructed.getCompactionMinSegments()).isEqualTo(3);
+    assertThat(reconstructed.getCompactionMaxSegments()).isEqualTo(6);
+    assertThat(reconstructed.getCompactionMinFragmentation()).isEqualTo(0.2);
+    assertThat(reconstructed.getCompactionAgeBiasWeight()).isEqualTo(0.4);
+    assertThat(reconstructed.getCompactionSizeBiasWeight()).isEqualTo(0.4);
+    assertThat(reconstructed.getCompactionFragBiasWeight()).isEqualTo(0.2);
+    assertThat(reconstructed.getCodebookBatchLoadSize()).isEqualTo(5_000);
+    assertThat(reconstructed.getAdjacencyBatchLoadSize()).isEqualTo(3_000);
+    assertThat(reconstructed.isPrefetchCodebooksEnabled()).isFalse();
+    assertThat(reconstructed.isPrefetchCodebooksSync()).isTrue();
+    assertThat(reconstructed.getMetricAttributes()).containsEntry("env", "test");
+
+    // Assert local workers are disabled
+    assertThat(reconstructed.getLocalWorkerThreads()).isZero();
+    assertThat(reconstructed.getLocalMaintenanceWorkerThreads()).isZero();
+
+    // Assert data-format fields match the persisted IndexMeta (from the index we created)
+    assertThat(reconstructed.getDimension()).isEqualTo(4);
+    assertThat(reconstructed.getPqM()).isEqualTo(2);
+    assertThat(reconstructed.getPqK()).isEqualTo(8);
+    assertThat(reconstructed.getGraphDegree()).isEqualTo(4);
+    assertThat(reconstructed.getMaxSegmentSize()).isEqualTo(2);
   }
 }

--- a/src/test/java/io/github/panghy/vectorsearch/tasks/GlobalTaskQueueEdgeCaseTest.java
+++ b/src/test/java/io/github/panghy/vectorsearch/tasks/GlobalTaskQueueEdgeCaseTest.java
@@ -286,6 +286,83 @@ class GlobalTaskQueueEdgeCaseTest {
     assertThat(result).isTrue();
   }
 
+  // ---- Test 11b: Build task with empty index_path fails claim ----
+  @Test
+  void workerRunner_buildTask_emptyIndexPath_failsClaim() throws Exception {
+    WorkerConfig workerCfg = WorkerConfig.builder().build();
+    runner = new GlobalWorkerRunner(db, workerCfg, globalConfig);
+    // Enqueue a build task with no index_path
+    GlobalBuildTask task = GlobalBuildTask.newBuilder()
+        .setTask(BuildTask.newBuilder().setSegId(0).build())
+        .build();
+    globalBuildQueue.enqueueIfNotExists("empty-path-build", task).get(5, TimeUnit.SECONDS);
+    // runOnceBuild should claim and fail it (not crash)
+    Boolean result = runner.runOnceBuild().get(5, TimeUnit.SECONDS);
+    assertThat(result).isTrue();
+  }
+
+  // ---- Test 11c: Build task with missing inner task payload fails claim ----
+  @Test
+  void workerRunner_buildTask_missingPayload_failsClaim() throws Exception {
+    WorkerConfig workerCfg = WorkerConfig.builder().build();
+    runner = new GlobalWorkerRunner(db, workerCfg, globalConfig);
+    // Enqueue a GlobalBuildTask with no inner BuildTask set
+    GlobalBuildTask task = GlobalBuildTask.newBuilder()
+        .addIndexPath("some")
+        .addIndexPath("path")
+        .build();
+    globalBuildQueue.enqueueIfNotExists("no-payload-build", task).get(5, TimeUnit.SECONDS);
+    Boolean result = runner.runOnceBuild().get(5, TimeUnit.SECONDS);
+    assertThat(result).isTrue();
+  }
+
+  // ---- Test 11d: Maintenance task with empty index_path fails claim ----
+  @Test
+  void workerRunner_maintTask_emptyIndexPath_failsClaim() throws Exception {
+    WorkerConfig workerCfg = WorkerConfig.builder().build();
+    runner = new GlobalWorkerRunner(db, workerCfg, globalConfig);
+    // Enqueue a maintenance task with no index_path
+    GlobalMaintenanceTask task = GlobalMaintenanceTask.newBuilder()
+        .setTask(MaintenanceTask.newBuilder()
+            .setVacuum(
+                MaintenanceTask.Vacuum.newBuilder().setSegId(0).build())
+            .build())
+        .build();
+    globalMaintQueue.enqueueIfNotExists("empty-path-maint", task).get(5, TimeUnit.SECONDS);
+    Boolean result = runner.runOnceMaint().get(5, TimeUnit.SECONDS);
+    assertThat(result).isTrue();
+  }
+
+  // ---- Test 11e: Maintenance task with missing inner task payload fails claim ----
+  @Test
+  void workerRunner_maintTask_missingPayload_failsClaim() throws Exception {
+    WorkerConfig workerCfg = WorkerConfig.builder().build();
+    runner = new GlobalWorkerRunner(db, workerCfg, globalConfig);
+    // Enqueue a GlobalMaintenanceTask with no inner MaintenanceTask set
+    GlobalMaintenanceTask task = GlobalMaintenanceTask.newBuilder()
+        .addIndexPath("some")
+        .addIndexPath("path")
+        .build();
+    globalMaintQueue.enqueueIfNotExists("no-payload-maint", task).get(5, TimeUnit.SECONDS);
+    Boolean result = runner.runOnceMaint().get(5, TimeUnit.SECONDS);
+    assertThat(result).isTrue();
+  }
+
+  // ---- Test 11f: Build task with blank index_path element fails claim ----
+  @Test
+  void workerRunner_buildTask_blankIndexPathElement_failsClaim() throws Exception {
+    WorkerConfig workerCfg = WorkerConfig.builder().build();
+    runner = new GlobalWorkerRunner(db, workerCfg, globalConfig);
+    GlobalBuildTask task = GlobalBuildTask.newBuilder()
+        .addIndexPath("valid")
+        .addIndexPath("")
+        .setTask(BuildTask.newBuilder().setSegId(0).build())
+        .build();
+    globalBuildQueue.enqueueIfNotExists("blank-element-build", task).get(5, TimeUnit.SECONDS);
+    Boolean result = runner.runOnceBuild().get(5, TimeUnit.SECONDS);
+    assertThat(result).isTrue();
+  }
+
   // ---- Test 12: GlobalTaskQueueConfig rejects null buildQueue ----
   @Test
   void globalTaskQueueConfig_nullBuildQueue_throwsNullPointerException() {

--- a/src/test/java/io/github/panghy/vectorsearch/tasks/GlobalTaskQueueEdgeCaseTest.java
+++ b/src/test/java/io/github/panghy/vectorsearch/tasks/GlobalTaskQueueEdgeCaseTest.java
@@ -161,6 +161,7 @@ class GlobalTaskQueueEdgeCaseTest {
     // Claim from global queue and verify wrapping
     var claim = globalBuildQueue.awaitAndClaimTask(db).get(10, TimeUnit.SECONDS);
     GlobalBuildTask gbt = claim.task();
+    assertThat(claim.taskKey()).isEqualTo("idx/path:key1");
     assertThat(gbt.getIndexPathList()).containsExactly("idx", "path");
     assertThat(gbt.getTask().getSegId()).isEqualTo(42);
     claim.complete().get(5, TimeUnit.SECONDS);
@@ -173,9 +174,8 @@ class GlobalTaskQueueEdgeCaseTest {
     BuildTask bt = BuildTask.newBuilder().setSegId(7).build();
     db.runAsync(tr -> adapter.enqueue(tr, "key2", bt, Duration.ofSeconds(10), Duration.ofMillis(50)))
         .get(5, TimeUnit.SECONDS);
-    // Allow throttle to elapse before claiming to avoid flakiness under concurrent FDB load
-    Thread.sleep(200);
     var claim = globalBuildQueue.awaitAndClaimTask(db).get(30, TimeUnit.SECONDS);
+    assertThat(claim.taskKey()).isEqualTo("my/index:key2");
     assertThat(claim.task().getIndexPathList()).containsExactly("my", "index");
     assertThat(claim.task().getTask().getSegId()).isEqualTo(7);
     claim.complete().get(5, TimeUnit.SECONDS);
@@ -191,6 +191,7 @@ class GlobalTaskQueueEdgeCaseTest {
         .build();
     db.runAsync(tr -> adapter.enqueueIfNotExists(tr, "mkey", mt)).get(5, TimeUnit.SECONDS);
     var claim = globalMaintQueue.awaitAndClaimTask(db).get(10, TimeUnit.SECONDS);
+    assertThat(claim.taskKey()).isEqualTo("m/idx:mkey");
     assertThat(claim.task().getIndexPathList()).containsExactly("m", "idx");
     assertThat(claim.task().getTask().getVacuum().getSegId()).isEqualTo(3);
     claim.complete().get(5, TimeUnit.SECONDS);

--- a/src/test/java/io/github/panghy/vectorsearch/tasks/GlobalTaskQueueEdgeCaseTest.java
+++ b/src/test/java/io/github/panghy/vectorsearch/tasks/GlobalTaskQueueEdgeCaseTest.java
@@ -22,6 +22,7 @@ import io.github.panghy.vectorsearch.proto.GlobalBuildTask;
 import io.github.panghy.vectorsearch.proto.GlobalMaintenanceTask;
 import io.github.panghy.vectorsearch.proto.IndexMeta;
 import io.github.panghy.vectorsearch.proto.MaintenanceTask;
+import io.github.panghy.vectorsearch.proto.SegmentMeta;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.List;
@@ -549,5 +550,161 @@ class GlobalTaskQueueEdgeCaseTest {
     assertThat(reconstructed.getPqK()).isEqualTo(8);
     assertThat(reconstructed.getGraphDegree()).isEqualTo(4);
     assertThat(reconstructed.getMaxSegmentSize()).isEqualTo(2);
+  }
+
+  // ---- Test: Vacuum follow-up FindCompactionCandidates goes to global queue ----
+  @Test
+  void vacuumFollowUp_findCandidates_enqueuesOnGlobalQueue() throws Exception {
+    // Create index with autoFindCompactionCandidates enabled and small maxSegmentSize
+    // so that after vacuum the segment count < maxSegmentSize/2 triggers follow-up.
+    VectorIndexConfig cfg = VectorIndexConfig.builder(db, root)
+        .dimension(4)
+        .pqM(2)
+        .pqK(8)
+        .graphDegree(4)
+        .maxSegmentSize(100) // large enough that count < 50 triggers follow-up
+        .vacuumMinDeletedRatio(0.0)
+        .autoFindCompactionCandidates(true)
+        .globalTaskQueueConfig(globalConfig)
+        .build();
+    index = VectorIndex.createOrOpen(cfg).get(10, TimeUnit.SECONDS);
+
+    // Insert 2 vectors and seal segment 0
+    long g0 = index.add(new float[] {1, 0, 0, 0}, null).get(5, TimeUnit.SECONDS);
+    index.add(new float[] {0, 1, 0, 0}, null).get(5, TimeUnit.SECONDS);
+    var dirs = FdbDirectories.openIndex(root, db).get(5, TimeUnit.SECONDS);
+    new SegmentBuildService(cfg, dirs).build(0).get(30, TimeUnit.SECONDS);
+
+    // Delete a vector to create a tombstone
+    index.delete(g0).get(5, TimeUnit.SECONDS);
+
+    // Claim and fail the vacuum task so the runner can re-claim it
+    var vacClaim = globalMaintQueue.awaitAndClaimTask(db).get(5, TimeUnit.SECONDS);
+    assertThat(vacClaim.task().getTask().hasVacuum()).isTrue();
+    vacClaim.fail().get(5, TimeUnit.SECONDS);
+
+    // Process the vacuum via GlobalWorkerRunner
+    WorkerConfig workerCfg =
+        WorkerConfig.builder().autoFindCompactionCandidates(true).build();
+    runner = new GlobalWorkerRunner(db, workerCfg, globalConfig);
+    runner.runOnceMaint().get(30, TimeUnit.SECONDS);
+
+    // The vacuum follow-up should have enqueued a FindCompactionCandidates on the GLOBAL queue
+    var followUp = globalMaintQueue.awaitAndClaimTask(db).get(10, TimeUnit.SECONDS);
+    GlobalMaintenanceTask gmt = followUp.task();
+    assertThat(gmt.getTask().hasFindCandidates()).isTrue();
+    assertThat(gmt.getIndexPathList()).isEqualTo(root.getPath());
+    followUp.complete().get(5, TimeUnit.SECONDS);
+  }
+
+  // ---- Test: FindCompactionCandidates marks COMPACTING and enqueues Compact on global queue ----
+  @Test
+  void findCandidates_marksCOMPACTING_enqueuesCompactOnGlobalQueue() throws Exception {
+    // Create index with 2 small sealed segments to be compaction candidates
+    VectorIndexConfig cfg = VectorIndexConfig.builder(db, root)
+        .dimension(4)
+        .pqM(2)
+        .pqK(8)
+        .graphDegree(4)
+        .maxSegmentSize(2)
+        .maxConcurrentCompactions(2)
+        .compactionMinSegments(2)
+        .compactionMinFragmentation(0.0) // no fragmentation threshold
+        .globalTaskQueueConfig(globalConfig)
+        .build();
+    index = VectorIndex.createOrOpen(cfg).get(10, TimeUnit.SECONDS);
+
+    // Insert vectors to fill seg 0 and trigger rotation
+    index.add(new float[] {1, 0, 0, 0}, null).get(5, TimeUnit.SECONDS);
+    index.add(new float[] {0, 1, 0, 0}, null).get(5, TimeUnit.SECONDS);
+    index.add(new float[] {0, 0, 1, 0}, null).get(5, TimeUnit.SECONDS);
+
+    // Build seg 0 via runner
+    WorkerConfig workerCfg = WorkerConfig.builder()
+        .maxConcurrentCompactions(2)
+        .compactionMinSegments(2)
+        .compactionMinFragmentation(0.0)
+        .build();
+    runner = new GlobalWorkerRunner(db, workerCfg, globalConfig);
+    runner.runOnceBuild().get(30, TimeUnit.SECONDS);
+
+    // Insert more to fill seg 1 and trigger rotation
+    index.add(new float[] {0, 0, 0, 1}, null).get(5, TimeUnit.SECONDS);
+    index.add(new float[] {1, 1, 0, 0}, null).get(5, TimeUnit.SECONDS);
+
+    // Build seg 1
+    runner.runOnceBuild().get(30, TimeUnit.SECONDS);
+
+    // Now enqueue a FindCompactionCandidates task on the global queue
+    MaintenanceTask fcc = MaintenanceTask.newBuilder()
+        .setFindCandidates(MaintenanceTask.FindCompactionCandidates.newBuilder()
+            .setAnchorSegId(0)
+            .build())
+        .build();
+    GlobalMaintenanceTask gmt = GlobalMaintenanceTask.newBuilder()
+        .addAllIndexPath(root.getPath())
+        .setTask(fcc)
+        .build();
+    globalMaintQueue.enqueue("find-candidates:0", gmt).get(5, TimeUnit.SECONDS);
+
+    // Process the FindCompactionCandidates task
+    runner.runOnceMaint().get(30, TimeUnit.SECONDS);
+
+    // Verify segments are marked COMPACTING
+    var dirs = FdbDirectories.openIndex(root, db).get(5, TimeUnit.SECONDS);
+    SegmentMeta seg0 = db.readAsync(tr -> dirs.segmentKeys(tr, 0)
+            .thenCompose(sk -> tr.get(sk.metaKey()))
+            .thenApply(b -> {
+              try {
+                return SegmentMeta.parseFrom(b);
+              } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+                throw new RuntimeException(e);
+              }
+            }))
+        .get(5, TimeUnit.SECONDS);
+    assertThat(seg0.getState()).isEqualTo(SegmentMeta.State.COMPACTING);
+
+    // Verify a Compact task was enqueued on the global queue
+    var compactClaim = globalMaintQueue.awaitAndClaimTask(db).get(10, TimeUnit.SECONDS);
+    assertThat(compactClaim.task().getTask().hasCompact()).isTrue();
+    assertThat(compactClaim.task().getIndexPathList()).isEqualTo(root.getPath());
+    compactClaim.complete().get(5, TimeUnit.SECONDS);
+  }
+
+  // ---- Test: FindCompactionCandidates with maxConcurrentCompactions=0 is no-op ----
+  @Test
+  void findCandidates_maxConcurrentCompactionsZero_isNoOp() throws Exception {
+    VectorIndexConfig cfg = VectorIndexConfig.builder(db, root)
+        .dimension(4)
+        .pqM(2)
+        .pqK(8)
+        .graphDegree(4)
+        .maxSegmentSize(2)
+        .maxConcurrentCompactions(0)
+        .globalTaskQueueConfig(globalConfig)
+        .build();
+    index = VectorIndex.createOrOpen(cfg).get(10, TimeUnit.SECONDS);
+
+    // Enqueue a FindCompactionCandidates task
+    MaintenanceTask fcc = MaintenanceTask.newBuilder()
+        .setFindCandidates(MaintenanceTask.FindCompactionCandidates.newBuilder()
+            .setAnchorSegId(0)
+            .build())
+        .build();
+    GlobalMaintenanceTask gmt = GlobalMaintenanceTask.newBuilder()
+        .addAllIndexPath(root.getPath())
+        .setTask(fcc)
+        .build();
+    globalMaintQueue.enqueue("find-candidates:0", gmt).get(5, TimeUnit.SECONDS);
+
+    // Process with maxConcurrentCompactions=0
+    WorkerConfig workerCfg =
+        WorkerConfig.builder().maxConcurrentCompactions(0).build();
+    runner = new GlobalWorkerRunner(db, workerCfg, globalConfig);
+    runner.runOnceMaint().get(30, TimeUnit.SECONDS);
+
+    // No Compact task should be enqueued — queue should be empty
+    boolean empty = db.runAsync(tr -> globalMaintQueue.isEmpty(tr)).get(5, TimeUnit.SECONDS);
+    assertThat(empty).isTrue();
   }
 }

--- a/src/test/java/io/github/panghy/vectorsearch/tasks/GlobalTaskQueueEdgeCaseTest.java
+++ b/src/test/java/io/github/panghy/vectorsearch/tasks/GlobalTaskQueueEdgeCaseTest.java
@@ -1,0 +1,498 @@
+package io.github.panghy.vectorsearch.tasks;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.apple.foundationdb.Database;
+import com.apple.foundationdb.FDB;
+import com.apple.foundationdb.directory.DirectoryLayer;
+import com.apple.foundationdb.directory.DirectorySubspace;
+import com.google.protobuf.ByteString;
+import io.github.panghy.taskqueue.TaskQueue;
+import io.github.panghy.taskqueue.TaskQueueConfig;
+import io.github.panghy.taskqueue.TaskQueues;
+import io.github.panghy.vectorsearch.api.VectorIndex;
+import io.github.panghy.vectorsearch.config.GlobalTaskQueueConfig;
+import io.github.panghy.vectorsearch.config.VectorIndexConfig;
+import io.github.panghy.vectorsearch.fdb.FdbDirectories;
+import io.github.panghy.vectorsearch.proto.BuildTask;
+import io.github.panghy.vectorsearch.proto.GlobalBuildTask;
+import io.github.panghy.vectorsearch.proto.GlobalMaintenanceTask;
+import io.github.panghy.vectorsearch.proto.IndexMeta;
+import io.github.panghy.vectorsearch.proto.MaintenanceTask;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Edge case tests for the global task queue feature.
+ *
+ * <p>Covers adapter null checks, unsupported method exceptions, serializer round-trips,
+ * {@link GlobalWorkerRunner} lifecycle (start/close/sentinel handling),
+ * {@link GlobalTaskQueueConfig} validation, {@link VectorIndexConfig#isGlobalTaskQueueEnabled()},
+ * config reconstruction from {@link IndexMeta}, and missing IndexMeta handling.</p>
+ */
+class GlobalTaskQueueEdgeCaseTest {
+
+  private Database db;
+  private DirectorySubspace root;
+  private DirectorySubspace globalDir;
+  private TaskQueue<String, GlobalBuildTask> globalBuildQueue;
+  private TaskQueue<String, GlobalMaintenanceTask> globalMaintQueue;
+  private GlobalTaskQueueConfig globalConfig;
+  private GlobalWorkerRunner runner;
+  private VectorIndex index;
+
+  @BeforeEach
+  void setup() throws Exception {
+    db = FDB.selectAPIVersion(730).open();
+    String uid = UUID.randomUUID().toString();
+    root = db.runAsync(tr -> DirectoryLayer.getDefault()
+            .createOrOpen(
+                tr, List.of("vs-edge-test", uid), "vectorsearch".getBytes(StandardCharsets.UTF_8)))
+        .get(5, TimeUnit.SECONDS);
+
+    globalDir = db.runAsync(tr -> DirectoryLayer.getDefault().createOrOpen(tr, List.of("vs-edge-queues", uid)))
+        .get(5, TimeUnit.SECONDS);
+
+    DirectorySubspace buildDir =
+        globalDir.createOrOpen(db, List.of("build")).get(5, TimeUnit.SECONDS);
+    TaskQueueConfig<String, GlobalBuildTask> buildTqc = TaskQueueConfig.builder(
+            db,
+            buildDir,
+            new ProtoSerializers.StringSerializer(),
+            new ProtoSerializers.GlobalBuildTaskSerializer())
+        .defaultTtl(Duration.ofSeconds(30))
+        .defaultThrottle(Duration.ofMillis(50))
+        .build();
+    globalBuildQueue = TaskQueues.createTaskQueue(buildTqc).get(5, TimeUnit.SECONDS);
+
+    DirectorySubspace maintDir =
+        globalDir.createOrOpen(db, List.of("maint")).get(5, TimeUnit.SECONDS);
+    TaskQueueConfig<String, GlobalMaintenanceTask> maintTqc = TaskQueueConfig.builder(
+            db,
+            maintDir,
+            new ProtoSerializers.StringSerializer(),
+            new ProtoSerializers.GlobalMaintenanceTaskSerializer())
+        .defaultTtl(Duration.ofSeconds(30))
+        .defaultThrottle(Duration.ofMillis(50))
+        .build();
+    globalMaintQueue = TaskQueues.createTaskQueue(maintTqc).get(5, TimeUnit.SECONDS);
+
+    globalConfig = new GlobalTaskQueueConfig(globalBuildQueue, globalMaintQueue);
+  }
+
+  @AfterEach
+  void teardown() {
+    if (runner != null) runner.close();
+    if (index != null) index.close();
+    if (db != null) {
+      db.run(tr -> {
+        root.remove(tr);
+        globalDir.remove(tr);
+        return null;
+      });
+      db.close();
+    }
+  }
+
+  // ---- Test 1: Build adapter unsupported consumer/inspection methods ----
+  @Test
+  void buildAdapter_unsupportedMethods_throwUnsupportedOperationException() {
+    GlobalBuildQueueAdapter adapter = new GlobalBuildQueueAdapter(globalBuildQueue, List.of("a"));
+    assertThatThrownBy(adapter::getConfig).isInstanceOf(UnsupportedOperationException.class);
+    assertThatThrownBy(() -> adapter.awaitAndClaimTask(db)).isInstanceOf(UnsupportedOperationException.class);
+    assertThatThrownBy(() -> adapter.completeTask(null, null)).isInstanceOf(UnsupportedOperationException.class);
+    assertThatThrownBy(() -> adapter.failTask(null, null)).isInstanceOf(UnsupportedOperationException.class);
+    assertThatThrownBy(() -> adapter.extendTtl(null, null, Duration.ofSeconds(1)))
+        .isInstanceOf(UnsupportedOperationException.class);
+    assertThatThrownBy(() -> adapter.isEmpty(null)).isInstanceOf(UnsupportedOperationException.class);
+    assertThatThrownBy(() -> adapter.hasVisibleUnclaimedTasks(null))
+        .isInstanceOf(UnsupportedOperationException.class);
+    assertThatThrownBy(() -> adapter.hasClaimedTasks(null)).isInstanceOf(UnsupportedOperationException.class);
+  }
+
+  // ---- Test 1b: Maintenance adapter unsupported methods ----
+  @Test
+  void maintAdapter_unsupportedMethods_throwUnsupportedOperationException() {
+    GlobalMaintenanceQueueAdapter adapter = new GlobalMaintenanceQueueAdapter(globalMaintQueue, List.of("a"));
+    assertThatThrownBy(adapter::getConfig).isInstanceOf(UnsupportedOperationException.class);
+    assertThatThrownBy(() -> adapter.awaitAndClaimTask(db)).isInstanceOf(UnsupportedOperationException.class);
+    assertThatThrownBy(() -> adapter.completeTask(null, null)).isInstanceOf(UnsupportedOperationException.class);
+    assertThatThrownBy(() -> adapter.failTask(null, null)).isInstanceOf(UnsupportedOperationException.class);
+    assertThatThrownBy(() -> adapter.extendTtl(null, null, Duration.ofSeconds(1)))
+        .isInstanceOf(UnsupportedOperationException.class);
+    assertThatThrownBy(() -> adapter.isEmpty(null)).isInstanceOf(UnsupportedOperationException.class);
+    assertThatThrownBy(() -> adapter.hasVisibleUnclaimedTasks(null))
+        .isInstanceOf(UnsupportedOperationException.class);
+    assertThatThrownBy(() -> adapter.hasClaimedTasks(null)).isInstanceOf(UnsupportedOperationException.class);
+  }
+
+  // ---- Test 2: Maintenance adapter awaitQueueEmpty throws ----
+  @Test
+  void maintAdapter_awaitQueueEmpty_throwsUnsupportedOperationException() {
+    GlobalMaintenanceQueueAdapter adapter = new GlobalMaintenanceQueueAdapter(globalMaintQueue, List.of("a"));
+    assertThatThrownBy(() -> adapter.awaitQueueEmpty(db)).isInstanceOf(UnsupportedOperationException.class);
+  }
+
+  // ---- Test 3: Build adapter awaitQueueEmpty delegates ----
+  @Test
+  void buildAdapter_awaitQueueEmpty_delegatesToGlobalQueue() throws Exception {
+    GlobalBuildQueueAdapter adapter = new GlobalBuildQueueAdapter(globalBuildQueue, List.of("a"));
+    // Queue is empty, so awaitQueueEmpty should complete immediately
+    adapter.awaitQueueEmpty(db).get(5, TimeUnit.SECONDS);
+  }
+
+  // ---- Test 4: Adapter enqueue methods wrap correctly and claim verifies wrapping ----
+  @Test
+  void buildAdapter_enqueueAndClaim_wrapsCorrectly() throws Exception {
+    GlobalBuildQueueAdapter adapter = new GlobalBuildQueueAdapter(globalBuildQueue, List.of("idx", "path"));
+    BuildTask bt = BuildTask.newBuilder().setSegId(42).build();
+    // Enqueue via simple overload
+    db.runAsync(tr -> adapter.enqueueIfNotExists(tr, "key1", bt)).get(5, TimeUnit.SECONDS);
+    // Claim from global queue and verify wrapping
+    var claim = globalBuildQueue.awaitAndClaimTask(db).get(10, TimeUnit.SECONDS);
+    GlobalBuildTask gbt = claim.task();
+    assertThat(gbt.getIndexPathList()).containsExactly("idx", "path");
+    assertThat(gbt.getTask().getSegId()).isEqualTo(42);
+    claim.complete().get(5, TimeUnit.SECONDS);
+  }
+
+  // ---- Test 5: Adapter enqueue wraps correctly ----
+  @Test
+  void buildAdapter_enqueue_wrapsCorrectly() throws Exception {
+    GlobalBuildQueueAdapter adapter = new GlobalBuildQueueAdapter(globalBuildQueue, List.of("my", "index"));
+    BuildTask bt = BuildTask.newBuilder().setSegId(7).build();
+    db.runAsync(tr -> adapter.enqueue(tr, "key2", bt, Duration.ofSeconds(10), Duration.ofMillis(50)))
+        .get(5, TimeUnit.SECONDS);
+    var claim = globalBuildQueue.awaitAndClaimTask(db).get(10, TimeUnit.SECONDS);
+    assertThat(claim.task().getIndexPathList()).containsExactly("my", "index");
+    assertThat(claim.task().getTask().getSegId()).isEqualTo(7);
+    claim.complete().get(5, TimeUnit.SECONDS);
+  }
+
+  // ---- Test 5b: Maintenance adapter enqueue wraps correctly ----
+  @Test
+  void maintAdapter_enqueueIfNotExists_wrapsCorrectly() throws Exception {
+    GlobalMaintenanceQueueAdapter adapter =
+        new GlobalMaintenanceQueueAdapter(globalMaintQueue, List.of("m", "idx"));
+    MaintenanceTask mt = MaintenanceTask.newBuilder()
+        .setVacuum(MaintenanceTask.Vacuum.newBuilder().setSegId(3).build())
+        .build();
+    db.runAsync(tr -> adapter.enqueueIfNotExists(tr, "mkey", mt)).get(5, TimeUnit.SECONDS);
+    var claim = globalMaintQueue.awaitAndClaimTask(db).get(10, TimeUnit.SECONDS);
+    assertThat(claim.task().getIndexPathList()).containsExactly("m", "idx");
+    assertThat(claim.task().getTask().getVacuum().getSegId()).isEqualTo(3);
+    claim.complete().get(5, TimeUnit.SECONDS);
+  }
+
+  // ---- Test 6: Adapter constructors reject nulls ----
+  @Test
+  void buildAdapter_nullGlobalQueue_throwsNullPointerException() {
+    assertThatThrownBy(() -> new GlobalBuildQueueAdapter(null, List.of("a")))
+        .isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  void buildAdapter_nullIndexPath_throwsNullPointerException() {
+    assertThatThrownBy(() -> new GlobalBuildQueueAdapter(globalBuildQueue, null))
+        .isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  void maintAdapter_nullGlobalQueue_throwsNullPointerException() {
+    assertThatThrownBy(() -> new GlobalMaintenanceQueueAdapter(null, List.of("a")))
+        .isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  void maintAdapter_nullIndexPath_throwsNullPointerException() {
+    assertThatThrownBy(() -> new GlobalMaintenanceQueueAdapter(globalMaintQueue, null))
+        .isInstanceOf(NullPointerException.class);
+  }
+
+  // ---- Test 7: start(0,0) is no-op ----
+  @Test
+  void workerRunner_startZeroZero_isNoOp() {
+    VectorIndexConfig templateCfg = VectorIndexConfig.builder(db, root)
+        .dimension(4)
+        .pqM(2)
+        .pqK(8)
+        .graphDegree(4)
+        .build();
+    runner = new GlobalWorkerRunner(db, templateCfg, globalConfig);
+    runner.start(0, 0);
+    assertThat(runner.isRunning()).isFalse();
+  }
+
+  // ---- Test 8: double start is idempotent ----
+  @Test
+  void workerRunner_doubleStart_isIdempotent() {
+    VectorIndexConfig templateCfg = VectorIndexConfig.builder(db, root)
+        .dimension(4)
+        .pqM(2)
+        .pqK(8)
+        .graphDegree(4)
+        .build();
+    runner = new GlobalWorkerRunner(db, templateCfg, globalConfig);
+    runner.start(1, 0);
+    assertThat(runner.isRunning()).isTrue();
+    // Second start should be no-op
+    runner.start(2, 2);
+    assertThat(runner.isRunning()).isTrue();
+  }
+
+  // ---- Test 9: close sets isRunning to false ----
+  @Test
+  void workerRunner_close_setsIsRunningFalse() {
+    VectorIndexConfig templateCfg = VectorIndexConfig.builder(db, root)
+        .dimension(4)
+        .pqM(2)
+        .pqK(8)
+        .graphDegree(4)
+        .build();
+    runner = new GlobalWorkerRunner(db, templateCfg, globalConfig);
+    runner.start(1, 1);
+    assertThat(runner.isRunning()).isTrue();
+    runner.close();
+    assertThat(runner.isRunning()).isFalse();
+    runner = null; // prevent double-close in teardown
+  }
+
+  // ---- Test 10: Build sentinel is claimed and completed ----
+  @Test
+  void workerRunner_buildSentinel_claimedAndCompleted() throws Exception {
+    VectorIndexConfig templateCfg = VectorIndexConfig.builder(db, root)
+        .dimension(4)
+        .pqM(2)
+        .pqK(8)
+        .graphDegree(4)
+        .build();
+    runner = new GlobalWorkerRunner(db, templateCfg, globalConfig);
+    // Enqueue a build sentinel
+    GlobalBuildTask sentinel = GlobalBuildTask.newBuilder()
+        .setTask(BuildTask.newBuilder().setSegId(-1).build())
+        .build();
+    globalBuildQueue.enqueueIfNotExists("sentinel-build", sentinel).get(5, TimeUnit.SECONDS);
+    // runOnceBuild should claim and complete it without error
+    Boolean result = runner.runOnceBuild().get(5, TimeUnit.SECONDS);
+    assertThat(result).isTrue();
+  }
+
+  // ---- Test 11: Maintenance sentinel is claimed and completed ----
+  @Test
+  void workerRunner_maintSentinel_claimedAndCompleted() throws Exception {
+    VectorIndexConfig templateCfg = VectorIndexConfig.builder(db, root)
+        .dimension(4)
+        .pqM(2)
+        .pqK(8)
+        .graphDegree(4)
+        .build();
+    runner = new GlobalWorkerRunner(db, templateCfg, globalConfig);
+    // Enqueue a maintenance sentinel
+    GlobalMaintenanceTask sentinel = GlobalMaintenanceTask.newBuilder()
+        .setTask(MaintenanceTask.newBuilder()
+            .setVacuum(
+                MaintenanceTask.Vacuum.newBuilder().setSegId(-1).build())
+            .build())
+        .build();
+    globalMaintQueue.enqueueIfNotExists("sentinel-maint", sentinel).get(5, TimeUnit.SECONDS);
+    Boolean result = runner.runOnceMaint().get(5, TimeUnit.SECONDS);
+    assertThat(result).isTrue();
+  }
+
+  // ---- Test 12: GlobalTaskQueueConfig rejects null buildQueue ----
+  @Test
+  void globalTaskQueueConfig_nullBuildQueue_throwsNullPointerException() {
+    assertThatThrownBy(() -> new GlobalTaskQueueConfig(null, globalMaintQueue))
+        .isInstanceOf(NullPointerException.class);
+  }
+
+  // ---- Test 13: GlobalTaskQueueConfig rejects null maintenanceQueue ----
+  @Test
+  void globalTaskQueueConfig_nullMaintenanceQueue_throwsNullPointerException() {
+    assertThatThrownBy(() -> new GlobalTaskQueueConfig(globalBuildQueue, null))
+        .isInstanceOf(NullPointerException.class);
+  }
+
+  // ---- Test 14: isGlobalTaskQueueEnabled returns false by default ----
+  @Test
+  void vectorIndexConfig_isGlobalTaskQueueEnabled_falseByDefault() {
+    VectorIndexConfig cfg = VectorIndexConfig.builder(db, root).dimension(4).build();
+    assertThat(cfg.isGlobalTaskQueueEnabled()).isFalse();
+    assertThat(cfg.getGlobalTaskQueueConfig()).isNull();
+  }
+
+  // ---- Test 15: isGlobalTaskQueueEnabled returns true when set ----
+  @Test
+  void vectorIndexConfig_isGlobalTaskQueueEnabled_trueWhenSet() {
+    VectorIndexConfig cfg = VectorIndexConfig.builder(db, root)
+        .dimension(4)
+        .globalTaskQueueConfig(globalConfig)
+        .build();
+    assertThat(cfg.isGlobalTaskQueueEnabled()).isTrue();
+    assertThat(cfg.getGlobalTaskQueueConfig()).isSameAs(globalConfig);
+  }
+
+  // ---- Test 16: GlobalBuildTaskSerializer round-trip ----
+  @Test
+  void globalBuildTaskSerializer_roundTrip() {
+    ProtoSerializers.GlobalBuildTaskSerializer serializer = new ProtoSerializers.GlobalBuildTaskSerializer();
+    GlobalBuildTask original = GlobalBuildTask.newBuilder()
+        .addAllIndexPath(List.of("test", "index"))
+        .setTask(BuildTask.newBuilder().setSegId(99).build())
+        .build();
+    ByteString bytes = serializer.serialize(original);
+    GlobalBuildTask deserialized = serializer.deserialize(bytes);
+    assertThat(deserialized.getIndexPathList()).containsExactly("test", "index");
+    assertThat(deserialized.getTask().getSegId()).isEqualTo(99);
+  }
+
+  // ---- Test 17: GlobalMaintenanceTaskSerializer round-trip ----
+  @Test
+  void globalMaintenanceTaskSerializer_roundTrip() {
+    ProtoSerializers.GlobalMaintenanceTaskSerializer serializer =
+        new ProtoSerializers.GlobalMaintenanceTaskSerializer();
+    GlobalMaintenanceTask original = GlobalMaintenanceTask.newBuilder()
+        .addAllIndexPath(List.of("maint", "path"))
+        .setTask(MaintenanceTask.newBuilder()
+            .setVacuum(MaintenanceTask.Vacuum.newBuilder()
+                .setSegId(5)
+                .setMinDeletedRatio(0.3)
+                .build())
+            .build())
+        .build();
+    ByteString bytes = serializer.serialize(original);
+    GlobalMaintenanceTask deserialized = serializer.deserialize(bytes);
+    assertThat(deserialized.getIndexPathList()).containsExactly("maint", "path");
+    assertThat(deserialized.getTask().getVacuum().getSegId()).isEqualTo(5);
+    assertThat(deserialized.getTask().getVacuum().getMinDeletedRatio()).isEqualTo(0.3);
+  }
+
+  // ---- Test 18: Serializers handle null input ----
+  @Test
+  void globalBuildTaskSerializer_nullInput_returnsEmpty() {
+    ProtoSerializers.GlobalBuildTaskSerializer serializer = new ProtoSerializers.GlobalBuildTaskSerializer();
+    ByteString bytes = serializer.serialize(null);
+    assertThat(bytes).isEqualTo(ByteString.EMPTY);
+  }
+
+  @Test
+  void globalMaintenanceTaskSerializer_nullInput_returnsEmpty() {
+    ProtoSerializers.GlobalMaintenanceTaskSerializer serializer =
+        new ProtoSerializers.GlobalMaintenanceTaskSerializer();
+    ByteString bytes = serializer.serialize(null);
+    assertThat(bytes).isEqualTo(ByteString.EMPTY);
+  }
+
+  @Test
+  void globalBuildTaskSerializer_nullDeserialize_returnsDefault() {
+    ProtoSerializers.GlobalBuildTaskSerializer serializer = new ProtoSerializers.GlobalBuildTaskSerializer();
+    GlobalBuildTask result = serializer.deserialize(null);
+    assertThat(result).isEqualTo(GlobalBuildTask.getDefaultInstance());
+  }
+
+  @Test
+  void globalMaintenanceTaskSerializer_nullDeserialize_returnsDefault() {
+    ProtoSerializers.GlobalMaintenanceTaskSerializer serializer =
+        new ProtoSerializers.GlobalMaintenanceTaskSerializer();
+    GlobalMaintenanceTask result = serializer.deserialize(null);
+    assertThat(result).isEqualTo(GlobalMaintenanceTask.getDefaultInstance());
+  }
+
+  // ---- Test 19: Config reconstruction reads IndexMeta data params ----
+  @Test
+  void workerRunner_configReconstruction_usesIndexMetaDataParams() throws Exception {
+    // Create an index with specific params
+    VectorIndexConfig cfg = VectorIndexConfig.builder(db, root)
+        .dimension(16)
+        .metric(VectorIndexConfig.Metric.COSINE)
+        .pqM(8)
+        .pqK(32)
+        .graphDegree(64)
+        .maxSegmentSize(2)
+        .oversample(3)
+        .globalTaskQueueConfig(globalConfig)
+        .build();
+    index = VectorIndex.createOrOpen(cfg).get(10, TimeUnit.SECONDS);
+
+    // Insert enough vectors to trigger rotation (maxSegmentSize=2)
+    index.add(new float[] {1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, null)
+        .get(5, TimeUnit.SECONDS);
+    index.add(new float[] {0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, null)
+        .get(5, TimeUnit.SECONDS);
+    index.add(new float[] {0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, null)
+        .get(5, TimeUnit.SECONDS);
+
+    // Verify IndexMeta was written with correct params
+    var dirs = FdbDirectories.openIndex(root, db).get(5, TimeUnit.SECONDS);
+    byte[] metaBytes = db.readAsync(tr -> tr.get(dirs.metaKey())).get(5, TimeUnit.SECONDS);
+    assertThat(metaBytes).isNotNull();
+    IndexMeta meta = IndexMeta.parseFrom(metaBytes);
+    assertThat(meta.getDimension()).isEqualTo(16);
+    assertThat(meta.getMetric()).isEqualTo(IndexMeta.Metric.METRIC_COSINE);
+    assertThat(meta.getPqM()).isEqualTo(8);
+    assertThat(meta.getPqK()).isEqualTo(32);
+    assertThat(meta.getGraphDegree()).isEqualTo(64);
+
+    // Create a template with different data params — worker should use IndexMeta's params
+    VectorIndexConfig templateCfg = VectorIndexConfig.builder(db, root)
+        .dimension(4)
+        .pqM(2)
+        .pqK(8)
+        .graphDegree(4)
+        .maxSegmentSize(2)
+        .estimatedWorkerCount(1)
+        .defaultTtl(Duration.ofSeconds(30))
+        .build();
+    runner = new GlobalWorkerRunner(db, templateCfg, globalConfig);
+    // Process the build task — should succeed using IndexMeta's dimension=16
+    runner.runOnceBuild().get(30, TimeUnit.SECONDS);
+  }
+
+  // ---- Test 20: Missing IndexMeta fails the task, doesn't crash ----
+  @Test
+  void workerRunner_missingIndexMeta_failsTaskGracefully() throws Exception {
+    // Create a directory but don't write IndexMeta
+    DirectorySubspace emptyDir = db.runAsync(tr -> DirectoryLayer.getDefault()
+            .createOrOpen(
+                tr,
+                List.of("vs-edge-test", "empty-" + UUID.randomUUID()),
+                "vectorsearch".getBytes(StandardCharsets.UTF_8)))
+        .get(5, TimeUnit.SECONDS);
+    try {
+      // Open index dirs so the directory structure exists
+      FdbDirectories.openIndex(emptyDir, db).get(5, TimeUnit.SECONDS);
+
+      // Enqueue a build task pointing to this empty directory
+      GlobalBuildTask task = GlobalBuildTask.newBuilder()
+          .addAllIndexPath(emptyDir.getPath())
+          .setTask(BuildTask.newBuilder().setSegId(0).build())
+          .build();
+      globalBuildQueue.enqueueIfNotExists("missing-meta-task", task).get(5, TimeUnit.SECONDS);
+
+      VectorIndexConfig templateCfg = VectorIndexConfig.builder(db, root)
+          .dimension(4)
+          .pqM(2)
+          .pqK(8)
+          .graphDegree(4)
+          .build();
+      runner = new GlobalWorkerRunner(db, templateCfg, globalConfig);
+
+      // runOnceBuild should fail the task (not crash the runner)
+      // The task will be claimed, fail due to missing IndexMeta, and be marked failed
+      Boolean result = runner.runOnceBuild().get(10, TimeUnit.SECONDS);
+      assertThat(result).isTrue(); // Task was processed (claimed + failed)
+    } finally {
+      db.run(tr -> {
+        emptyDir.remove(tr);
+        return null;
+      });
+    }
+  }
+}

--- a/src/test/java/io/github/panghy/vectorsearch/tasks/GlobalTaskQueueIntegrationTest.java
+++ b/src/test/java/io/github/panghy/vectorsearch/tasks/GlobalTaskQueueIntegrationTest.java
@@ -1,0 +1,339 @@
+package io.github.panghy.vectorsearch.tasks;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.apple.foundationdb.Database;
+import com.apple.foundationdb.FDB;
+import com.apple.foundationdb.directory.DirectoryLayer;
+import com.apple.foundationdb.directory.DirectorySubspace;
+import io.github.panghy.taskqueue.TaskQueue;
+import io.github.panghy.taskqueue.TaskQueueConfig;
+import io.github.panghy.taskqueue.TaskQueues;
+import io.github.panghy.vectorsearch.api.VectorIndex;
+import io.github.panghy.vectorsearch.config.GlobalTaskQueueConfig;
+import io.github.panghy.vectorsearch.config.VectorIndexConfig;
+import io.github.panghy.vectorsearch.fdb.FdbDirectories;
+import io.github.panghy.vectorsearch.fdb.FdbVectorIndex;
+import io.github.panghy.vectorsearch.proto.GlobalBuildTask;
+import io.github.panghy.vectorsearch.proto.GlobalMaintenanceTask;
+import io.github.panghy.vectorsearch.proto.SegmentMeta;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Integration tests for the global task queue feature.
+ *
+ * <p>Verifies end-to-end flows: inserting vectors with global queues enabled routes build/maintenance
+ * tasks to shared global queues, {@link GlobalWorkerRunner} processes them, and multiple indices
+ * can share the same global queues. Also verifies that local worker pools are not started when
+ * global mode is enabled.</p>
+ */
+class GlobalTaskQueueIntegrationTest {
+
+  private Database db;
+  private DirectorySubspace root;
+  private DirectorySubspace globalDir;
+  private TaskQueue<String, GlobalBuildTask> globalBuildQueue;
+  private TaskQueue<String, GlobalMaintenanceTask> globalMaintQueue;
+  private GlobalTaskQueueConfig globalConfig;
+  private VectorIndex index;
+  private VectorIndex index2;
+  private GlobalWorkerRunner runner;
+
+  @BeforeEach
+  void setup() throws Exception {
+    db = FDB.selectAPIVersion(730).open();
+    String uid = UUID.randomUUID().toString();
+    root = db.runAsync(tr -> DirectoryLayer.getDefault()
+            .createOrOpen(
+                tr, List.of("vs-global-test", uid), "vectorsearch".getBytes(StandardCharsets.UTF_8)))
+        .get(5, TimeUnit.SECONDS);
+
+    // Create global queue directories
+    globalDir = db.runAsync(tr -> DirectoryLayer.getDefault().createOrOpen(tr, List.of("vs-global-queues", uid)))
+        .get(5, TimeUnit.SECONDS);
+
+    DirectorySubspace buildDir =
+        globalDir.createOrOpen(db, List.of("build")).get(5, TimeUnit.SECONDS);
+    TaskQueueConfig<String, GlobalBuildTask> buildTqc = TaskQueueConfig.builder(
+            db,
+            buildDir,
+            new ProtoSerializers.StringSerializer(),
+            new ProtoSerializers.GlobalBuildTaskSerializer())
+        .build();
+    globalBuildQueue = TaskQueues.createTaskQueue(buildTqc).get(5, TimeUnit.SECONDS);
+
+    DirectorySubspace maintDir =
+        globalDir.createOrOpen(db, List.of("maint")).get(5, TimeUnit.SECONDS);
+    TaskQueueConfig<String, GlobalMaintenanceTask> maintTqc = TaskQueueConfig.builder(
+            db,
+            maintDir,
+            new ProtoSerializers.StringSerializer(),
+            new ProtoSerializers.GlobalMaintenanceTaskSerializer())
+        .build();
+    globalMaintQueue = TaskQueues.createTaskQueue(maintTqc).get(5, TimeUnit.SECONDS);
+
+    globalConfig = new GlobalTaskQueueConfig(globalBuildQueue, globalMaintQueue);
+  }
+
+  @AfterEach
+  void teardown() {
+    if (runner != null) runner.close();
+    if (index != null) index.close();
+    if (index2 != null) index2.close();
+    if (db != null) {
+      db.run(tr -> {
+        root.remove(tr);
+        globalDir.remove(tr);
+        return null;
+      });
+      db.close();
+    }
+  }
+
+  @Test
+  void insertVectors_segmentRotation_buildTaskAppearsInGlobalQueue() throws Exception {
+    VectorIndexConfig cfg = VectorIndexConfig.builder(db, root)
+        .dimension(4)
+        .pqM(2)
+        .pqK(8)
+        .graphDegree(4)
+        .maxSegmentSize(2)
+        .globalTaskQueueConfig(globalConfig)
+        .build();
+    index = VectorIndex.createOrOpen(cfg).get(10, TimeUnit.SECONDS);
+
+    // Insert 2 vectors to fill seg 0, then 1 more to trigger rotation
+    index.add(new float[] {1, 0, 0, 0}, null).get(5, TimeUnit.SECONDS);
+    index.add(new float[] {0, 1, 0, 0}, null).get(5, TimeUnit.SECONDS);
+    index.add(new float[] {0, 0, 1, 0}, null).get(5, TimeUnit.SECONDS);
+
+    // Claim the build task from the global queue and verify it has the correct index path
+    var claim = globalBuildQueue.awaitAndClaimTask(db).get(5, TimeUnit.SECONDS);
+    GlobalBuildTask gbt = claim.task();
+    assertThat(gbt.getTask().getSegId()).isEqualTo(0);
+    assertThat(gbt.getIndexPathList()).isEqualTo(root.getPath());
+    claim.complete().get(5, TimeUnit.SECONDS);
+  }
+
+  @Test
+  void globalWorkerRunner_buildsAndSealsSegment() throws Exception {
+    VectorIndexConfig cfg = VectorIndexConfig.builder(db, root)
+        .dimension(4)
+        .pqM(2)
+        .pqK(8)
+        .graphDegree(4)
+        .maxSegmentSize(2)
+        .globalTaskQueueConfig(globalConfig)
+        .build();
+    index = VectorIndex.createOrOpen(cfg).get(10, TimeUnit.SECONDS);
+
+    // Template config for the worker
+    VectorIndexConfig templateCfg = VectorIndexConfig.builder(db, root)
+        .dimension(4)
+        .pqM(2)
+        .pqK(8)
+        .graphDegree(4)
+        .maxSegmentSize(2)
+        .estimatedWorkerCount(1)
+        .defaultTtl(Duration.ofSeconds(30))
+        .build();
+
+    runner = new GlobalWorkerRunner(db, templateCfg, globalConfig);
+    runner.start(1, 0);
+
+    // Insert vectors to trigger rotation
+    index.add(new float[] {1, 0, 0, 0}, null).get(5, TimeUnit.SECONDS);
+    index.add(new float[] {0, 1, 0, 0}, null).get(5, TimeUnit.SECONDS);
+    index.add(new float[] {0, 0, 1, 0}, null).get(5, TimeUnit.SECONDS);
+
+    // Wait for the global build queue to drain
+    index.awaitIndexingComplete().get(30, TimeUnit.SECONDS);
+
+    // Verify segment 0 is SEALED
+    var dirs = FdbDirectories.openIndex(root, db).get(5, TimeUnit.SECONDS);
+    SegmentMeta seg0 = db.readAsync(tr -> dirs.segmentKeys(tr, 0)
+            .thenCompose(sk -> tr.get(sk.metaKey()))
+            .thenApply(b -> {
+              try {
+                return SegmentMeta.parseFrom(b);
+              } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+                throw new RuntimeException(e);
+              }
+            }))
+        .get(5, TimeUnit.SECONDS);
+    assertThat(seg0.getState()).isEqualTo(SegmentMeta.State.SEALED);
+  }
+
+  @Test
+  void deleteVectors_vacuumTaskInGlobalMaintenanceQueue() throws Exception {
+    VectorIndexConfig cfg = VectorIndexConfig.builder(db, root)
+        .dimension(4)
+        .pqM(2)
+        .pqK(8)
+        .graphDegree(4)
+        .maxSegmentSize(10)
+        .vacuumMinDeletedRatio(0.0)
+        .globalTaskQueueConfig(globalConfig)
+        .build();
+    index = VectorIndex.createOrOpen(cfg).get(10, TimeUnit.SECONDS);
+
+    // Insert vectors and seal segment 0 manually
+    long g0 = index.add(new float[] {1, 0, 0, 0}, null).get(5, TimeUnit.SECONDS);
+    index.add(new float[] {0, 1, 0, 0}, null).get(5, TimeUnit.SECONDS);
+    var dirs = FdbDirectories.openIndex(root, db).get(5, TimeUnit.SECONDS);
+    new SegmentBuildService(cfg, dirs).build(0).get(5, TimeUnit.SECONDS);
+
+    // Delete a vector — should enqueue vacuum into global maintenance queue
+    index.delete(g0).get(5, TimeUnit.SECONDS);
+
+    // Claim the maintenance task and verify it's a vacuum for seg 0
+    var claim = globalMaintQueue.awaitAndClaimTask(db).get(5, TimeUnit.SECONDS);
+    GlobalMaintenanceTask gmt = claim.task();
+    assertThat(gmt.getTask().hasVacuum()).isTrue();
+    assertThat(gmt.getTask().getVacuum().getSegId()).isEqualTo(0);
+    assertThat(gmt.getIndexPathList()).isEqualTo(root.getPath());
+
+    // Now start a GlobalWorkerRunner to process it
+    VectorIndexConfig templateCfg = VectorIndexConfig.builder(db, root)
+        .dimension(4)
+        .pqM(2)
+        .pqK(8)
+        .graphDegree(4)
+        .build();
+    // Fail the claim so the worker can re-claim it
+    claim.fail().get(5, TimeUnit.SECONDS);
+
+    runner = new GlobalWorkerRunner(db, templateCfg, globalConfig);
+    // Process the maintenance task via runOnceMaint
+    runner.runOnceMaint().get(30, TimeUnit.SECONDS);
+  }
+
+  @Test
+  void twoIndices_sharedGlobalQueues_bothServiced() throws Exception {
+    // Create two separate index directories
+    DirectorySubspace root2 = db.runAsync(tr -> DirectoryLayer.getDefault()
+            .createOrOpen(
+                tr,
+                List.of("vs-global-test", UUID.randomUUID().toString()),
+                "vectorsearch".getBytes(StandardCharsets.UTF_8)))
+        .get(5, TimeUnit.SECONDS);
+
+    VectorIndexConfig cfg1 = VectorIndexConfig.builder(db, root)
+        .dimension(4)
+        .pqM(2)
+        .pqK(8)
+        .graphDegree(4)
+        .maxSegmentSize(2)
+        .globalTaskQueueConfig(globalConfig)
+        .build();
+    VectorIndexConfig cfg2 = VectorIndexConfig.builder(db, root2)
+        .dimension(4)
+        .pqM(2)
+        .pqK(8)
+        .graphDegree(4)
+        .maxSegmentSize(2)
+        .globalTaskQueueConfig(globalConfig)
+        .build();
+
+    index = VectorIndex.createOrOpen(cfg1).get(10, TimeUnit.SECONDS);
+    index2 = VectorIndex.createOrOpen(cfg2).get(10, TimeUnit.SECONDS);
+
+    // Create a global worker (not started as a loop — we'll call runOnceBuild directly)
+    VectorIndexConfig templateCfg = VectorIndexConfig.builder(db, root)
+        .dimension(4)
+        .pqM(2)
+        .pqK(8)
+        .graphDegree(4)
+        .maxSegmentSize(2)
+        .estimatedWorkerCount(1)
+        .defaultTtl(Duration.ofSeconds(30))
+        .build();
+    runner = new GlobalWorkerRunner(db, templateCfg, globalConfig);
+
+    // Trigger rotation on index 1 first, process its build task
+    index.add(new float[] {1, 0, 0, 0}, null).get(5, TimeUnit.SECONDS);
+    index.add(new float[] {0, 1, 0, 0}, null).get(5, TimeUnit.SECONDS);
+    index.add(new float[] {0, 0, 1, 0}, null).get(5, TimeUnit.SECONDS);
+    runner.runOnceBuild().get(30, TimeUnit.SECONDS);
+
+    // Verify index 1 segment 0 is SEALED
+    var dirs1 = FdbDirectories.openIndex(root, db).get(5, TimeUnit.SECONDS);
+    SegmentMeta seg0_1 = db.readAsync(tr -> dirs1.segmentKeys(tr, 0)
+            .thenCompose(sk -> tr.get(sk.metaKey()))
+            .thenApply(b -> {
+              try {
+                return SegmentMeta.parseFrom(b);
+              } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+                throw new RuntimeException(e);
+              }
+            }))
+        .get(5, TimeUnit.SECONDS);
+    assertThat(seg0_1.getState()).isEqualTo(SegmentMeta.State.SEALED);
+
+    // Now trigger rotation on index 2 and process its build task
+    index2.add(new float[] {1, 1, 0, 0}, null).get(5, TimeUnit.SECONDS);
+    index2.add(new float[] {0, 1, 1, 0}, null).get(5, TimeUnit.SECONDS);
+    index2.add(new float[] {0, 0, 1, 1}, null).get(5, TimeUnit.SECONDS);
+    runner.runOnceBuild().get(30, TimeUnit.SECONDS);
+
+    // Verify index 2 segment 0 is SEALED
+    var dirs2 = FdbDirectories.openIndex(root2, db).get(5, TimeUnit.SECONDS);
+    SegmentMeta seg0_2 = db.readAsync(tr -> dirs2.segmentKeys(tr, 0)
+            .thenCompose(sk -> tr.get(sk.metaKey()))
+            .thenApply(b -> {
+              try {
+                return SegmentMeta.parseFrom(b);
+              } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+                throw new RuntimeException(e);
+              }
+            }))
+        .get(5, TimeUnit.SECONDS);
+    assertThat(seg0_2.getState()).isEqualTo(SegmentMeta.State.SEALED);
+
+    // Clean up root2
+    db.run(tr -> {
+      root2.remove(tr);
+      return null;
+    });
+  }
+
+  @Test
+  void globalModeEnabled_noLocalWorkerPoolsStarted() throws Exception {
+    // Create index with global mode AND localWorkerThreads > 0
+    // The global mode should prevent local pools from starting
+    VectorIndexConfig cfg = VectorIndexConfig.builder(db, root)
+        .dimension(4)
+        .pqM(2)
+        .pqK(8)
+        .graphDegree(4)
+        .maxSegmentSize(2)
+        .localWorkerThreads(2)
+        .localMaintenanceWorkerThreads(2)
+        .globalTaskQueueConfig(globalConfig)
+        .build();
+    FdbVectorIndex fdbIndex = FdbVectorIndex.createOrOpen(cfg).get(10, TimeUnit.SECONDS);
+    index = fdbIndex;
+
+    // Insert vectors to trigger rotation — if local pools were started, they would
+    // try to claim from the adapter queues and throw UnsupportedOperationException
+    fdbIndex.add(new float[] {1, 0, 0, 0}, null).get(5, TimeUnit.SECONDS);
+    fdbIndex.add(new float[] {0, 1, 0, 0}, null).get(5, TimeUnit.SECONDS);
+    fdbIndex.add(new float[] {0, 0, 1, 0}, null).get(5, TimeUnit.SECONDS);
+
+    // Verify the build task is in the global queue (not consumed by local workers)
+    var claim = globalBuildQueue.awaitAndClaimTask(db).get(5, TimeUnit.SECONDS);
+    assertThat(claim.task().getTask().getSegId()).isEqualTo(0);
+    claim.complete().get(5, TimeUnit.SECONDS);
+
+    // Close should not throw — no local pools to shut down
+    fdbIndex.close();
+    index = null; // prevent double-close in teardown
+  }
+}

--- a/src/test/java/io/github/panghy/vectorsearch/tasks/GlobalTaskQueueIntegrationTest.java
+++ b/src/test/java/io/github/panghy/vectorsearch/tasks/GlobalTaskQueueIntegrationTest.java
@@ -12,6 +12,7 @@ import io.github.panghy.taskqueue.TaskQueues;
 import io.github.panghy.vectorsearch.api.VectorIndex;
 import io.github.panghy.vectorsearch.config.GlobalTaskQueueConfig;
 import io.github.panghy.vectorsearch.config.VectorIndexConfig;
+import io.github.panghy.vectorsearch.config.WorkerConfig;
 import io.github.panghy.vectorsearch.fdb.FdbDirectories;
 import io.github.panghy.vectorsearch.fdb.FdbVectorIndex;
 import io.github.panghy.vectorsearch.proto.GlobalBuildTask;
@@ -134,18 +135,13 @@ class GlobalTaskQueueIntegrationTest {
         .build();
     index = VectorIndex.createOrOpen(cfg).get(10, TimeUnit.SECONDS);
 
-    // Template config for the worker
-    VectorIndexConfig templateCfg = VectorIndexConfig.builder(db, root)
-        .dimension(4)
-        .pqM(2)
-        .pqK(8)
-        .graphDegree(4)
-        .maxSegmentSize(2)
+    // Worker config for the global runner
+    WorkerConfig workerCfg = WorkerConfig.builder()
         .estimatedWorkerCount(1)
         .defaultTtl(Duration.ofSeconds(30))
         .build();
 
-    runner = new GlobalWorkerRunner(db, templateCfg, globalConfig);
+    runner = new GlobalWorkerRunner(db, workerCfg, globalConfig);
     runner.start(1, 0);
 
     // Insert vectors to trigger rotation
@@ -201,16 +197,11 @@ class GlobalTaskQueueIntegrationTest {
     assertThat(gmt.getIndexPathList()).isEqualTo(root.getPath());
 
     // Now start a GlobalWorkerRunner to process it
-    VectorIndexConfig templateCfg = VectorIndexConfig.builder(db, root)
-        .dimension(4)
-        .pqM(2)
-        .pqK(8)
-        .graphDegree(4)
-        .build();
+    WorkerConfig workerCfg = WorkerConfig.builder().build();
     // Fail the claim so the worker can re-claim it
     claim.fail().get(5, TimeUnit.SECONDS);
 
-    runner = new GlobalWorkerRunner(db, templateCfg, globalConfig);
+    runner = new GlobalWorkerRunner(db, workerCfg, globalConfig);
     // Process the maintenance task via runOnceMaint
     runner.runOnceMaint().get(30, TimeUnit.SECONDS);
   }
@@ -246,16 +237,11 @@ class GlobalTaskQueueIntegrationTest {
     index2 = VectorIndex.createOrOpen(cfg2).get(10, TimeUnit.SECONDS);
 
     // Create a global worker (not started as a loop — we'll call runOnceBuild directly)
-    VectorIndexConfig templateCfg = VectorIndexConfig.builder(db, root)
-        .dimension(4)
-        .pqM(2)
-        .pqK(8)
-        .graphDegree(4)
-        .maxSegmentSize(2)
+    WorkerConfig workerCfg = WorkerConfig.builder()
         .estimatedWorkerCount(1)
         .defaultTtl(Duration.ofSeconds(30))
         .build();
-    runner = new GlobalWorkerRunner(db, templateCfg, globalConfig);
+    runner = new GlobalWorkerRunner(db, workerCfg, globalConfig);
 
     // Trigger rotation on index 1 first, process its build task
     index.add(new float[] {1, 0, 0, 0}, null).get(5, TimeUnit.SECONDS);


### PR DESCRIPTION
**Summary:**
Implements centralized (global) task queue support enabling background workers (build and maintenance) to run in a separate process and service multiple vector index instances from a single shared pool. When enabled, local task queues and workers are bypassed, allowing for true distributed processing.

**Changes:**
- **Proto definitions**: Added `GlobalBuildTask` and `GlobalMaintenanceTask` wrapper messages that carry index directory paths alongside original task payloads
- **Configuration**: Introduced `GlobalTaskQueueConfig` to hold shared build and maintenance queues; added optional `globalTaskQueueConfig` to `VectorIndexConfig`
- **Adapters**: Created `GlobalBuildQueueAdapter` and `GlobalMaintenanceQueueAdapter` that wrap per-index tasks with directory paths and delegate to global queues
- **Index integration**: Modified `FdbVectorIndex.createOrOpen()` to use adapters when global mode is enabled; local workers are skipped
- **Worker runner**: Implemented `GlobalWorkerRunner` — a standalone programmatic API that claims tasks from global queues, resolves index directories, reconstructs per-index configs from persisted `IndexMeta`, and dispatches to `SegmentBuildService` and `MaintenanceService`
- **Serializers**: Added `GlobalBuildTaskSerializer` and `GlobalMaintenanceTaskSerializer` for proto serialization
- **Tests**: Comprehensive integration tests covering multi-index scenarios, FIFO processing, and edge cases; all tests pass with coverage thresholds met

**Technical Details:**
- Data-format parameters (dimension, metric, pqM, pqK, graphDegree, etc.) are read from each index's persisted `IndexMeta`
- Operational parameters (compaction knobs, vacuum thresholds, transaction limits) come from a uniform template config
- Backward compatible — existing behavior unchanged when `globalTaskQueueConfig` is not set
- Uses sentinel tasks (seg_id < 0) for graceful worker shutdown

**Testing:**
- `GlobalTaskQueueIntegrationTest`: Multi-index enqueue routing, build/maintenance processing, FIFO ordering
- `GlobalTaskQueueEdgeCaseTest`: Serializer round-trips, concurrent operations, error handling
- All existing tests continue to pass; coverage thresholds maintained (≥90% line, ≥75% branch)

**Checklist:**
- [x] Proto messages and serializers implemented
- [x] `VectorIndexConfig` and `GlobalTaskQueueConfig` integration
- [x] Adapter queues route tasks correctly
- [x] `GlobalWorkerRunner` processes tasks from multiple indices
- [x] Integration tests cover all acceptance criteria
- [x] Build passes: `./gradlew build` with coverage verification
- [x] Code formatted: `./gradlew spotlessApply`

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author